### PR TITLE
Implement shorthand notation for anonymous function parameters

### DIFF
--- a/src/compiler/parsing/watf/grammar.js
+++ b/src/compiler/parsing/watf/grammar.js
@@ -478,15 +478,33 @@ function parse(tokensList: Array<Object>): Program {
           if (token.type === tokens.valtype) {
             valtype = token.value;
 
+            fnParams.push({
+              id,
+              valtype,
+            });
+
             eatToken();
+
+            /**
+             * Shorthand notation for multiple anonymous parameters
+             * @see https://webassembly.github.io/spec/core/text/types.html#function-types
+             * @see https://github.com/xtuc/js-webassembly-interpreter/issues/6
+             */
+            if (id === undefined) {
+              while ( token.type === tokens.valtype ) {
+                valtype = token.value;
+                fnParams.push({
+                  valtype,
+                });
+
+                eatToken();
+              }
+            }
+
           } else {
             throw new Error('Function param has no valtype');
           }
 
-          fnParams.push({
-            id,
-            valtype,
-          });
         } else
 
         /**

--- a/test/compiler/parsing/fixtures/watf/func/anonymous-func-with-multiple-params/actual.wast
+++ b/test/compiler/parsing/fixtures/watf/func/anonymous-func-with-multiple-params/actual.wast
@@ -1,0 +1,3 @@
+(func (param i32 i64 i32))
+(func (param f64 i32))
+(func (param f64 f64 f64 f64 f32 f32 f32 i32 i64))

--- a/test/compiler/parsing/fixtures/watf/func/anonymous-func-with-multiple-params/expected.json
+++ b/test/compiler/parsing/fixtures/watf/func/anonymous-func-with-multiple-params/expected.json
@@ -1,0 +1,71 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "Func",
+      "id": null,
+      "params": [
+        {
+          "valtype": "i32"
+        },
+        {
+          "valtype": "i64"
+        },
+        {
+          "valtype": "i32"
+        }
+      ],
+      "result": null,
+      "body": []
+    },
+    {
+      "type": "Func",
+      "id": null,
+      "params": [
+        {
+          "valtype": "f64"
+        },
+        {
+          "valtype": "i32"
+        }
+      ],
+      "result": null,
+      "body": []
+    },
+    {
+      "type": "Func",
+      "id": null,
+      "params": [
+        {
+          "valtype": "f64"
+        },
+        {
+          "valtype": "f64"
+        },
+        {
+          "valtype": "f64"
+        },
+        {
+          "valtype": "f64"
+        },
+        {
+          "valtype": "f32"
+        },
+        {
+          "valtype": "f32"
+        },
+        {
+          "valtype": "f32"
+        },
+        {
+          "valtype": "i32"
+        },
+        {
+          "valtype": "i64"
+        }
+      ],
+      "result": null,
+      "body": []
+    }
+  ]
+}


### PR DESCRIPTION
This aims to fix https://github.com/xtuc/js-webassembly-interpreter/issues/6. Let me know what you think, happy to adjust 👍 