### PR TITLE
Implement f32.max, f64.max, f32.min and f64.min

### DIFF
--- a/src/interpreter/kernel/exec.js
+++ b/src/interpreter/kernel/exec.js
@@ -786,6 +786,67 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
       break;
     }
 
+    case 'min': {
+
+      switch (instruction.object) {
+
+      case 'f32': {
+        const [c1, c2] = pop2('f32', 'f32');
+
+        pushResult(
+          binopf32(c2, c1, 'min')
+        );
+
+        break;
+      }
+
+      case 'f64': {
+        const [c1, c2] = pop2('f64', 'f64');
+
+        pushResult(
+          binopf64(c2, c1, 'min')
+        );
+
+        break;
+      }
+
+      default:
+        throw new RuntimeError('Unsupported operation ' + instruction.id + ' on ' + instruction.object);
+      }
+
+      break;
+    }
+
+    case 'max': {
+
+      switch (instruction.object) {
+
+      case 'f32': {
+        const [c1, c2] = pop2('f32', 'f32');
+
+        pushResult(
+          binopf32(c2, c1, 'max')
+        );
+
+        break;
+      }
+
+      case 'f64': {
+        const [c1, c2] = pop2('f64', 'f64');
+
+        pushResult(
+          binopf64(c2, c1, 'max')
+        );
+
+        break;
+      }
+
+      default:
+        throw new RuntimeError('Unsupported operation ' + instruction.id + ' on ' + instruction.object);
+      }
+
+      break;
+    }
     }
 
     if (typeof frame.trace === 'function') {

--- a/src/interpreter/kernel/instruction/binop.js
+++ b/src/interpreter/kernel/instruction/binop.js
@@ -1,6 +1,6 @@
 // @flow
 
-type Sign = '+' | '-' | '/' | '*' | '&' | '|' | '^' | '~';
+type Sign = '+' | '-' | '/' | '*' | '&' | '|' | '^' | '~' | 'min' | 'max';
 
 const i32 = require('../../runtime/values/i32');
 const i64 = require('../../runtime/values/i64');
@@ -44,6 +44,12 @@ function binop(
   // https://webassembly.github.io/spec/exec/numerics.html#op-ixor
   case '^':
     return createValue(c1.value ^ c2.value);
+
+  case 'min':
+    return createValue(Math.min(c1.value, c2.value));
+
+  case 'max':
+    return createValue(Math.max(c1.value, c2.value));
   }
 
   throw new Error('Unsupported binop: ' + sign);

--- a/test/compiler/parsing/fixtures/watf/instruction/f32.min/actual.wast
+++ b/test/compiler/parsing/fixtures/watf/instruction/f32.min/actual.wast
@@ -1,0 +1,5 @@
+(module
+  (func (
+    (f32.min)
+  ))
+)

--- a/test/compiler/parsing/fixtures/watf/instruction/f32.min/expected.json
+++ b/test/compiler/parsing/fixtures/watf/instruction/f32.min/expected.json
@@ -1,0 +1,25 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "Module",
+      "id": null,
+      "fields": [
+        {
+          "type": "Func",
+          "id": null,
+          "params": [],
+          "result": null,
+          "body": [
+            {
+              "type": "Instr",
+              "id": "min",
+              "object": "f32",
+              "args": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/interpreter/kernel/exec/numeric-instructions.js
+++ b/test/interpreter/kernel/exec/numeric-instructions.js
@@ -753,7 +753,7 @@ describe('kernel exec - numeric instructions', () => {
 
         // NaN results cannot be checked with assert.equal
         if (isNaN(res)) {
-          assert.equal(isNaN(res), true);
+          assert.isTrue(isNaN(res));
         } else {
           assert.equal(res, op.resEqual);
         }

--- a/test/interpreter/kernel/exec/numeric-instructions.js
+++ b/test/interpreter/kernel/exec/numeric-instructions.js
@@ -261,6 +261,209 @@ describe('kernel exec - numeric instructions', () => {
       resEqual: 5.0,
     },
 
+    {
+      name: 'f32.min',
+
+      args: [
+        {value: 5.0, type: 'f32'},
+        {value: 1000.7, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f32'),
+      ],
+
+      resEqual: 5.0,
+    },
+
+    {
+      name: 'f32.min',
+
+      args: [
+        {value: +0, type: 'f32'},
+        {value: -0, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f32'),
+      ],
+
+      resEqual: -0,
+    },
+
+    {
+      name: 'f32.min',
+
+      args: [
+        {value: Infinity, type: 'f32'},
+        {value: -Infinity, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f32'),
+      ],
+
+      resEqual: -Infinity,
+    },
+
+    {
+      name: 'f32.min',
+
+      args: [
+        {value: Infinity, type: 'f32'},
+        {value: 1234, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f32'),
+      ],
+
+      resEqual: 1234,
+    },
+
+    {
+      name: 'f32.min',
+
+      args: [
+        {value: NaN, type: 'f32'},
+        {value: 1234, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f32'),
+      ],
+
+      resEqual: NaN,
+    },
+
+    {
+      name: 'f32.min',
+
+      args: [
+        {value: 0.0000000000000000000000001, type: 'f32'},
+        {value: 0.00000000000000000000000001, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f32'),
+      ],
+
+      resEqual: 0.00000000000000000000000001,
+    },
+
+    {
+      name: 'f32.max',
+
+      args: [
+        {value: 5.0, type: 'f32'},
+        {value: 1000.7, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f32'),
+      ],
+
+      resEqual: 1000.7,
+    },
+
+    {
+      name: 'f32.max',
+
+      args: [
+        {value: +0, type: 'f32'},
+        {value: -0, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f32'),
+      ],
+
+      resEqual: +0,
+    },
+
+    {
+      name: 'f32.max',
+
+      args: [
+        {value: Infinity, type: 'f32'},
+        {value: -Infinity, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f32'),
+      ],
+
+      resEqual: Infinity,
+    },
+
+    {
+      name: 'f32.max',
+
+      args: [
+        {value: Infinity, type: 'f32'},
+        {value: 1234, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f32'),
+      ],
+
+      resEqual: Infinity,
+    },
+
+    {
+      name: 'f32.max',
+
+      args: [
+        {value: NaN, type: 'f32'},
+        {value: 1234, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f32'),
+      ],
+
+      resEqual: NaN,
+    },
+
+    {
+      name: 'f32.max',
+
+      args: [
+        {value: 0.0000000000000000000000001, type: 'f32'},
+        {value: 0.00000000000000000000000001, type: 'f32'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f32'),
+      ],
+
+      resEqual: 0.0000000000000000000000001,
+    },
 
     /**
      * Float 64 bits
@@ -333,6 +536,211 @@ describe('kernel exec - numeric instructions', () => {
 
       resEqual: 5.0,
     },
+
+    {
+      name: 'f64.min',
+
+      args: [
+        {value: 5.0, type: 'f64'},
+        {value: 1000.7, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f64'),
+      ],
+
+      resEqual: 5.0,
+    },
+
+    {
+      name: 'f64.min',
+
+      args: [
+        {value: +0, type: 'f64'},
+        {value: -0, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f64'),
+      ],
+
+      resEqual: -0,
+    },
+
+    {
+      name: 'f64.min',
+
+      args: [
+        {value: Infinity, type: 'f64'},
+        {value: -Infinity, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f64'),
+      ],
+
+      resEqual: -Infinity,
+    },
+
+    {
+      name: 'f64.min',
+
+      args: [
+        {value: Infinity, type: 'f64'},
+        {value: 1234, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f64'),
+      ],
+
+      resEqual: 1234,
+    },
+
+    {
+      name: 'f64.min',
+
+      args: [
+        {value: NaN, type: 'f64'},
+        {value: 1234, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f64'),
+      ],
+
+      resEqual: NaN,
+    },
+
+    {
+      name: 'f64.min',
+
+      args: [
+        {value: 0.0000000000000000000000001, type: 'f64'},
+        {value: 0.00000000000000000000000001, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('min', 'f64'),
+      ],
+
+      resEqual: 0.00000000000000000000000001,
+    },
+
+    {
+      name: 'f64.max',
+
+      args: [
+        {value: 5.0, type: 'f64'},
+        {value: 1000.7, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f64'),
+      ],
+
+      resEqual: 1000.7,
+    },
+
+    {
+      name: 'f64.max',
+
+      args: [
+        {value: +0, type: 'f64'},
+        {value: -0, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f64'),
+      ],
+
+      resEqual: +0,
+    },
+
+    {
+      name: 'f64.max',
+
+      args: [
+        {value: Infinity, type: 'f64'},
+        {value: -Infinity, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f64'),
+      ],
+
+      resEqual: Infinity,
+    },
+
+    {
+      name: 'f64.max',
+
+      args: [
+        {value: Infinity, type: 'f64'},
+        {value: 1234, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f64'),
+      ],
+
+      resEqual: Infinity,
+    },
+
+    {
+      name: 'f64.max',
+
+      args: [
+        {value: NaN, type: 'f64'},
+        {value: 1234, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f64'),
+      ],
+
+      resEqual: NaN,
+    },
+
+    {
+      name: 'f64.max',
+
+      args: [
+        {value: 0.0000000000000000000000001, type: 'f64'},
+        {value: 0.00000000000000000000000001, type: 'f64'},
+      ],
+
+      code: [
+        t.instruction('get_local', [0]),
+        t.instruction('get_local', [1]),
+        t.objectInstruction('max', 'f64'),
+      ],
+
+      resEqual: 0.0000000000000000000000001,
+    },
+
   ];
 
   operations.forEach((op) => {
@@ -343,7 +751,13 @@ describe('kernel exec - numeric instructions', () => {
         const stackFrame = createStackFrame(op.code, op.args);
         const res = executeStackFrame(stackFrame).value;
 
-        assert.equal(res, op.resEqual);
+        // NaN results cannot be checked with assert.equal
+        if (isNaN(res)) {
+          assert.equal(isNaN(res), true);
+        } else {
+          assert.equal(res, op.resEqual);
+        }
+
       });
 
       it('should assert validations - 1 missing arg', () => {


### PR DESCRIPTION
This is just a start. I think correct handling of `NaN` payloads would require more work than just `Math.min` and `Math.max`. I haven't fully looked into it though. Here are the relevant spec parts:

https://webassembly.github.io/spec/core/exec/numerics.html#op-fmin
https://webassembly.github.io/spec/core/syntax/values.html#syntax-payload
https://webassembly.github.io/spec/core/exec/numerics.html#nan-propagation