### PR TITLE
watch and bootstrap script added in make file #40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,17 @@ make-executables:
 clean:
 	rm -rf ./lib
 
+clean-all: clean
+	rm -rf ./node_modules
+
+bootstrap: clean-all
+	npm install
+
 build: clean
 	$(BABEL) --out-dir lib/ src/
+
+watch:
+	$(BABEL) --out-dir lib/ src/ --watch
 
 test: build
 	$(MOCHA) --recursive

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webassembly-interpreter",
-  "version": "0.0.12",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "description": "WebAssembly interpreter",
   "main": "lib/index.js",
-  "license": "GNU GPLv2",
+  "license": "GPL-2.0",
   "scripts": {
     "test": "make test",
     "build": "make build"


### PR DESCRIPTION
> npm WARN webassembly-interpreter@0.0.14 license should be a valid SPDX license expression

Also updated to valid licenses name, check created error during `npm install`

https://spdx.org/licenses/GPL-2.0.html