### PR TITLE
Added fp hex notation article link under 'Notes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Our runtime instance values.
 
 ## Notes
 
+-  Text format supports floating point hexadecimals as described in this article [maurobringolf.ch/2017/12/hexadecimal-floating-point-notation](https://maurobringolf.ch/2017/12/hexadecimal-floating-point-notation)
 -  get_local of identifier is not supported as in the binary format
 
 ## Source


### PR DESCRIPTION
I added it to *Notes* for now. If there will be more material we can put them into a separate section.