### PR TITLE
Support i32.or instruction

### DIFF
--- a/src/interpreter/kernel/exec.js
+++ b/src/interpreter/kernel/exec.js
@@ -993,6 +993,24 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
 
       break;
     }
+
+	/**
+	 * Bitwise operators
+	 */
+	case 'or': {
+	  switch (instruction.object) {
+
+	  case 'i32': {
+	  	const [c1, c2] = pop2('i32', 'i32');
+
+		pushResult(
+			binopi32(c1, c2, '|')
+		);
+
+		break;
+	  }
+	  }
+	}
     }
 
     if (typeof frame.trace === 'function') {

--- a/test/interpreter/fixtures/integer-or/exec.tjs
+++ b/test/interpreter/fixtures/integer-or/exec.tjs
@@ -6,3 +6,17 @@ it('should produce correct result', () => {
   assert.typeOf(res, 'number');
   assert.equal(res, 1);
 });
+
+it('should work on full 32 bit range', () => {
+  const res = m.exports.or(0x7FFFFFFF, 0x80000000);
+
+  assert.typeOf(res, 'number');
+  assert.equal(res, -1); // 0xFFFFFFF
+});
+
+it('should work on full 32 bit range with hex result', () => {
+  const res = m.exports.or(0xf0f0ffff, 0xfffff0f0);
+
+  assert.typeOf(res, 'number');
+  assert.equal(res, -1); // 0xFFFFFFFF
+});

--- a/test/interpreter/fixtures/integer-or/exec.tjs
+++ b/test/interpreter/fixtures/integer-or/exec.tjs
@@ -1,0 +1,8 @@
+const m = WebAssembly.instantiateFromSource(watfmodule);
+
+it('should produce correct result', () => {
+  const res = m.exports.or(0, 1);
+
+  assert.typeOf(res, 'number');
+  assert.equal(res, 1);
+});

--- a/test/interpreter/fixtures/integer-or/module.wast
+++ b/test/interpreter/fixtures/integer-or/module.wast
@@ -1,0 +1,8 @@
+(module
+  (func $or (param i32) (param i32) (result i32) (
+   (get_local 0)
+   (get_local 1)
+   (i32.or)
+  ))
+  (export "or" (func $or))
+)


### PR DESCRIPTION
The binary operation was already there, I just added a couple of test cases and supported it in the instruction switch in `exec.js`.

#1 