### PR TITLE
Use assert.deepEqual to properly test NaN and zeros

### DIFF
--- a/test/interpreter/kernel/exec/numeric-instructions.js
+++ b/test/interpreter/kernel/exec/numeric-instructions.js
@@ -751,12 +751,7 @@ describe('kernel exec - numeric instructions', () => {
         const stackFrame = createStackFrame(op.code, op.args);
         const res = executeStackFrame(stackFrame).value;
 
-        // NaN results cannot be checked with assert.equal
-        if (isNaN(res)) {
-          assert.isTrue(isNaN(res));
-        } else {
-          assert.equal(res, op.resEqual);
-        }
+		assert.deepEqual(res, op.resEqual);
 
       });
 

--- a/test/interpreter/kernel/exec/numeric-instructions.js
+++ b/test/interpreter/kernel/exec/numeric-instructions.js
@@ -751,7 +751,7 @@ describe('kernel exec - numeric instructions', () => {
         const stackFrame = createStackFrame(op.code, op.args);
         const res = executeStackFrame(stackFrame).value;
 
-		assert.deepEqual(res, op.resEqual);
+        assert.deepEqual(res, op.resEqual);
 
       });
 


### PR DESCRIPTION
Turns out that `assert.deepEqual` from `chai` is what we need:

* `NaN` is deepEqual to `NaN`
* `+0` is not deepEqual to `-0`