### PR TITLE
interpreter exec refactor

### DIFF
--- a/src/interpreter/kernel/exec.js
+++ b/src/interpreter/kernel/exec.js
@@ -724,65 +724,38 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
     }
 
     /**
-     * Numeric Instructions
-     *
-     * https://webassembly.github.io/spec/exec/instructions.html#numeric-instructions
+     * Unary operations
      */
-
-    case 'abs': {
-
-      switch (instruction.object) {
-
-      case 'f32': {
-        const c = pop1('f32');
-
-        pushResult(
-          unopf32(c, 'abs')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError('Unsupported operation ' + instruction.id + ' on ' + instruction.object);
-      }
-
-      break;
-    }
-
-
+    case 'abs':
     case 'neg': {
-
+      let unopFn;
       switch (instruction.object) {
-
-      case 'f32': {
-        const c = pop1('f32');
-
-        pushResult(
-          unopf32(c, 'neg')
-        );
-
-        break;
+        case 'i32': 
+          unopFn = unopi32;
+          break;
+        case 'i64': 
+          unopFn = unopi64;
+          break;
+        case 'f32': 
+          unopFn = unopf32;
+          break;
+        case 'f64': 
+          unopFn = unopf64;
+          break;
+        default:
+          throw new RuntimeError(
+            'Unsupported operation ' + instruction.id + ' on ' + instruction.object
+          );
       }
+      
+      const c = pop1('f32');
 
-      case 'f64': {
-        const c = pop1('f64');
-
-        pushResult(
-          unopf64(c, 'neg')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError('Unsupported operation ' + instruction.id + ' on ' + instruction.object);
-      }
+      pushResult(
+        unopf32(c, instruction.id)
+      );
 
       break;
     }
-
-
     }
 
     if (typeof frame.trace === 'function') {

--- a/src/interpreter/kernel/exec.js
+++ b/src/interpreter/kernel/exec.js
@@ -690,7 +690,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i32', 'i32');
 
         pushResult(
-          binopi32(c2, c1, '+')
+          binopi32(c2, c1, 'add')
         );
 
         break;
@@ -700,7 +700,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i64', 'i64');
 
         pushResult(
-          binopi64(c2, c1, '+')
+          binopi64(c2, c1, 'add')
         );
 
         break;
@@ -710,7 +710,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f32', 'f32');
 
         pushResult(
-          binopf32(c2, c1, '+')
+          binopf32(c2, c1, 'add')
         );
 
         break;
@@ -720,7 +720,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f64', 'f64');
 
         pushResult(
-          binopf64(c2, c1, '+')
+          binopf64(c2, c1, 'add')
         );
 
         break;
@@ -744,7 +744,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i32', 'i32');
 
         pushResult(
-          binopi32(c2, c1, '*')
+          binopi32(c2, c1, 'mul')
         );
 
         break;
@@ -754,7 +754,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i64', 'i64');
 
         pushResult(
-          binopi64(c2, c1, '*')
+          binopi64(c2, c1, 'mul')
         );
 
         break;
@@ -764,7 +764,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f32', 'f32');
 
         pushResult(
-          binopf32(c2, c1, '*')
+          binopf32(c2, c1, 'mul')
         );
 
         break;
@@ -774,7 +774,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f64', 'f64');
 
         pushResult(
-          binopf64(c2, c1, '*')
+          binopf64(c2, c1, 'mul')
         );
 
         break;
@@ -798,7 +798,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i32', 'i32');
 
         pushResult(
-          binopi32(c2, c1, '-')
+          binopi32(c2, c1, 'sub')
         );
 
         break;
@@ -808,7 +808,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i64', 'i64');
 
         pushResult(
-          binopi64(c2, c1, '-')
+          binopi64(c2, c1, 'sub')
         );
 
         break;
@@ -818,7 +818,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f32', 'f32');
 
         pushResult(
-          binopf32(c2, c1, '-')
+          binopf32(c2, c1, 'sub')
         );
 
         break;
@@ -828,7 +828,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f64', 'f64');
 
         pushResult(
-          binopf64(c2, c1, '-')
+          binopf64(c2, c1, 'sub')
         );
 
         break;
@@ -858,7 +858,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i32', 'i32');
 
         pushResult(
-          binopi32(c2, c1, '/')
+          binopi32(c2, c1, 'div')
         );
 
         break;
@@ -868,7 +868,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i64', 'i64');
 
         pushResult(
-          binopi64(c2, c1, '/')
+          binopi64(c2, c1, 'div')
         );
 
         break;
@@ -878,7 +878,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f32', 'f32');
 
         pushResult(
-          binopf32(c2, c1, '/')
+          binopf32(c2, c1, 'div')
         );
 
         break;
@@ -888,7 +888,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('f64', 'f64');
 
         pushResult(
-          binopf64(c2, c1, '/')
+          binopf64(c2, c1, 'div')
         );
 
         break;
@@ -1063,7 +1063,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i32', 'i32');
 
         pushResult(
-          binopi32(c1, c2, '|')
+          binopi32(c1, c2, 'or')
         );
 
         break;
@@ -1080,7 +1080,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
         const [c1, c2] = pop2('i32', 'i32');
 
         pushResult(
-          binopi32(c1, c2, '^')
+          binopi32(c1, c2, 'xor')
         );
 
         break;

--- a/src/interpreter/kernel/exec.js
+++ b/src/interpreter/kernel/exec.js
@@ -678,328 +678,56 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
     }
 
     /**
-     * Numeric Instructions
-     *
-     * https://webassembly.github.io/spec/exec/instructions.html#numeric-instructions
+     * Binary operations
      */
-    case 'add': {
-
+    case 'add':
+    case 'mul':
+    case 'sub':
+    /**
+     * There are two seperated operation for both signed and unsigned integer,
+     * but since the host environment will handle that, we don't have too :)
+     */
+    case 'div_s':
+    case 'div_u':
+    case 'div':
+    case 'min':
+    case 'max':
+    case 'copysign':
+    case 'or':
+    case 'xor': {
+      let binopFn;
       switch (instruction.object) {
-
-      case 'i32': {
-        const [c1, c2] = pop2('i32', 'i32');
-
-        pushResult(
-          binopi32(c2, c1, 'add')
-        );
-
-        break;
+        case 'i32': 
+          binopFn = binopi32;
+          break;
+        case 'i64': 
+          binopFn = binopi64;
+          break;
+        case 'f32': 
+          binopFn = binopf32;
+          break;
+        case 'f64': 
+          binopFn = binopf64;
+          break;
+        default:
+          throw new RuntimeError(
+            'Unsupported operation ' + instruction.id + ' on ' + instruction.object
+          );
       }
 
-      case 'i64': {
-        const [c1, c2] = pop2('i64', 'i64');
-
-        pushResult(
-          binopi64(c2, c1, 'add')
-        );
-
-        break;
-      }
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'add')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'add')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError(
-          'Unsupported operation ' + instruction.id + ' on ' + instruction.object
-        );
-
-      }
-
-      break;
-    }
-
-    case 'mul': {
-
-      switch (instruction.object) {
-
-      case 'i32': {
-        const [c1, c2] = pop2('i32', 'i32');
-
-        pushResult(
-          binopi32(c2, c1, 'mul')
-        );
-
-        break;
-      }
-
-      case 'i64': {
-        const [c1, c2] = pop2('i64', 'i64');
-
-        pushResult(
-          binopi64(c2, c1, 'mul')
-        );
-
-        break;
-      }
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'mul')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'mul')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError(
-          'Unsupported operation ' + instruction.id + ' on ' + instruction.object
-        );
-
-      }
-
-      break;
-    }
-
-    case 'sub': {
-
-      switch (instruction.object) {
-
-      case 'i32': {
-        const [c1, c2] = pop2('i32', 'i32');
-
-        pushResult(
-          binopi32(c2, c1, 'sub')
-        );
-
-        break;
-      }
-
-      case 'i64': {
-        const [c1, c2] = pop2('i64', 'i64');
-
-        pushResult(
-          binopi64(c2, c1, 'sub')
-        );
-
-        break;
-      }
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'sub')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'sub')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError(
-          'Unsupported operation ' + instruction.id + ' on ' + instruction.object
-        );
-
-      }
+      const [c1, c2] = pop2(instruction.object, instruction.object);
+      pushResult(
+        binopFn(c2, c1, instruction.id)
+      );
 
       break;
     }
 
     /**
-     * There is two seperated operation for both signed and unsigned integer,
-     * but since the host environment will handle that, we don't have too :)
+     * Numeric Instructions
+     *
+     * https://webassembly.github.io/spec/exec/instructions.html#numeric-instructions
      */
-    case 'div_s':
-    case 'div_u':
-    case 'div': {
-
-      switch (instruction.object) {
-
-      case 'i32': {
-        const [c1, c2] = pop2('i32', 'i32');
-
-        pushResult(
-          binopi32(c2, c1, 'div')
-        );
-
-        break;
-      }
-
-      case 'i64': {
-        const [c1, c2] = pop2('i64', 'i64');
-
-        pushResult(
-          binopi64(c2, c1, 'div')
-        );
-
-        break;
-      }
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'div')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'div')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError(
-          'Unsupported operation ' + instruction.id + ' on ' + instruction.object
-        );
-
-      }
-
-      break;
-    }
-
-    case 'min': {
-
-      switch (instruction.object) {
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'min')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'min')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError(
-          'Unsupported operation ' + instruction.id + ' on ' + instruction.object
-        );
-      }
-
-      break;
-    }
-
-    case 'max': {
-
-      switch (instruction.object) {
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'max')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'max')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError(
-          'Unsupported operation ' + instruction.id + ' on ' + instruction.object
-        );
-      }
-
-      break;
-    }
-
-    case 'copysign': {
-
-      switch (instruction.object) {
-
-      case 'f32': {
-        const [c1, c2] = pop2('f32', 'f32');
-
-        pushResult(
-          binopf32(c2, c1, 'copysign')
-        );
-
-        break;
-      }
-
-      case 'f64': {
-        const [c1, c2] = pop2('f64', 'f64');
-
-        pushResult(
-          binopf64(c2, c1, 'copysign')
-        );
-
-        break;
-      }
-
-      default:
-        throw new RuntimeError('Unsupported operation ' + instruction.id + ' on ' + instruction.object);
-      }
-
-      break;
-    }
 
     case 'abs': {
 
@@ -1021,6 +749,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
 
       break;
     }
+
 
     case 'neg': {
 
@@ -1053,42 +782,7 @@ export function executeStackFrame(frame: StackFrame, depth: number = 0): any {
       break;
     }
 
-    /**
-     * Bitwise operators
-     */
-    case 'or': {
-      switch (instruction.object) {
 
-      case 'i32': {
-        const [c1, c2] = pop2('i32', 'i32');
-
-        pushResult(
-          binopi32(c1, c2, 'or')
-        );
-
-        break;
-      }
-      }
-
-      break;
-    }
-
-    case 'xor': {
-      switch (instruction.object) {
-
-      case 'i32': {
-        const [c1, c2] = pop2('i32', 'i32');
-
-        pushResult(
-          binopi32(c1, c2, 'xor')
-        );
-
-        break;
-      }
-      }
-
-      break;
-    }
     }
 
     if (typeof frame.trace === 'function') {

--- a/src/interpreter/kernel/instruction/binop.js
+++ b/src/interpreter/kernel/instruction/binop.js
@@ -1,6 +1,6 @@
 // @flow
 
-type Sign = '+' | '-' | '/' | '*' | '&' | '|' | '^' | '~' | 'min' | 'max' | 'copysign';
+type Sign = 'add' | 'sub' | 'div' | 'div_s' | 'div_u' | 'mul' | 'and' | 'or' | 'xor' | '~' | 'min' | 'max' | 'copysign';
 
 const i32 = require('../../runtime/values/i32');
 const i64 = require('../../runtime/values/i64');
@@ -17,32 +17,34 @@ function binop(
 
   switch (sign) {
   // https://webassembly.github.io/spec/exec/numerics.html#op-iadd
-  case '+':
+  case 'add':
     return createValue(c1.value + c2.value);
 
     // https://webassembly.github.io/spec/exec/numerics.html#op-isub
-  case '-':
+  case 'sub':
     return createValue(c1.value - c2.value);
 
   // https://webassembly.github.io/spec/exec/numerics.html#op-imul
-  case '*':
+  case 'mul':
     return createValue(c1.value * c2.value);
 
   // https://webassembly.github.io/spec/exec/numerics.html#op-idiv-u
   // https://webassembly.github.io/spec/exec/numerics.html#op-idiv-s
-  case '/':
+  case 'div_s':
+  case 'div_u':
+  case 'div':
     return createValue(c1.value / c2.value);
 
   // https://webassembly.github.io/spec/exec/numerics.html#op-iand
-  case '&':
+  case 'and':
     return createValue(c1.value & c2.value);
 
   // https://webassembly.github.io/spec/exec/numerics.html#op-ior
-  case '|':
+  case 'or':
     return createValue(c1.value | c2.value);
 
   // https://webassembly.github.io/spec/exec/numerics.html#op-ixor
-  case '^':
+  case 'xor':
     return createValue(c1.value ^ c2.value);
 
   case 'min':

--- a/src/interpreter/kernel/instruction/unop.js
+++ b/src/interpreter/kernel/instruction/unop.js
@@ -1,6 +1,6 @@
 // @flow
 
-type Sign = 'abs';
+type Sign = 'abs' | 'neg';
 
 const i32 = require('../../runtime/values/i32');
 const i64 = require('../../runtime/values/i64');


### PR DESCRIPTION
Here is a proposed refactor ...

1. the binop computer now uses the instruction names, rather than JavaScript 'signs', i.e. '+' becomes 'add', removing a further look-up
2. kernel/exec has been refactored so that all binary operations share the same 'case' block.

I committed by own benchmark result before the refactor. Here is the mean time before and after:

mean 474.9725275000 ns
mean 481.3720141000 ns

If everyone is happy with this, I'll look at a similar change for unary operations.

(before merging, I'll remove the benchmark commit, and tidy up a few comments)

relates to #56 
  