### PR TITLE
[WIP] - adding a wrapper around numeric types

### DIFF
--- a/src/interpreter/index.js
+++ b/src/interpreter/index.js
@@ -1,5 +1,8 @@
 // @flow
 
+const {
+  castIntoStackLocalOfType
+} = require("./runtime/castIntoStackLocalOfType");
 const { traverse } = require("../compiler/AST/traverse");
 const modulevalue = require("./runtime/values/module");
 const { executeStackFrame } = require("./kernel/exec");
@@ -170,14 +173,9 @@ function createHostfunc(
       );
     }
 
-    const argsWithType = args.map((value: any, i: number): StackLocal => {
-      const type = funcinstArgs[i];
-
-      return {
-        value,
-        type
-      };
-    });
+    const argsWithType = args.map((value: any, i: number): StackLocal =>
+      castIntoStackLocalOfType(funcinstArgs[i], value)
+    );
 
     const stackFrame = createStackFrame(
       funcinst.code,
@@ -201,7 +199,7 @@ function createHostfunc(
     }
 
     if (typeof res !== "undefined") {
-      return res.value;
+      return res.value.toNumber();
     }
   };
 }

--- a/src/interpreter/kernel/instruction/binop.js
+++ b/src/interpreter/kernel/instruction/binop.js
@@ -1,5 +1,4 @@
 // @flow
-const Long = require("long");
 
 type Sign =
   | "add"
@@ -21,62 +20,7 @@ const i64 = require("../../runtime/values/i64");
 const f32 = require("../../runtime/values/f32");
 const f64 = require("../../runtime/values/f64");
 
-// https://webassembly.github.io/spec/core/exec/instructions.html#exec-binop
 function binop(
-  { value: c1 }: StackLocal,
-  { value: c2 }: StackLocal,
-  sign: Sign,
-  createValue: number => StackLocal
-): StackLocal {
-  switch (sign) {
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-iadd
-    case "add":
-      return createValue(c1 + c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-isub
-    case "sub":
-      return createValue(c1 - c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-imul
-    case "mul":
-      return createValue(c1 * c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-idiv-u
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-idiv-s
-    case "div_s":
-    case "div_u":
-    case "div":
-      return createValue(c1 / c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-iand
-    case "and":
-      return createValue(c1 & c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-ior
-    case "or":
-      return createValue(c1 | c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-ixor
-    case "xor":
-      return createValue(c1 ^ c2);
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-fmin
-    case "min":
-      return createValue(Math.min(c1, c2));
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-fmax
-    case "max":
-      return createValue(Math.max(c1, c2));
-
-    // https://webassembly.github.io/spec/core/exec/numerics.html#op-fcopysign
-    case "copysign":
-      return createValue(Math.sign(c1) === Math.sign(c2) ? c1 : -c1);
-  }
-
-  throw new Error("Unsupported binop: " + sign);
-}
-
-function binopLong(
   { value: c1 }: StackLocal,
   { value: c2 }: StackLocal,
   sign: Sign,
@@ -113,6 +57,18 @@ function binopLong(
     // https://webassembly.github.io/spec/core/exec/numerics.html#op-ixor
     case "xor":
       return createValue(c1.xor(c2));
+
+    // https://webassembly.github.io/spec/core/exec/numerics.html#op-fmin
+    case "min":
+      return createValue(c1.min(c2));
+
+    // https://webassembly.github.io/spec/core/exec/numerics.html#op-fmax
+    case "max":
+      return createValue(c1.max(c2));
+
+    // https://webassembly.github.io/spec/core/exec/numerics.html#op-fcopysign
+    case "copysign":
+      return createValue(c1.copysign(c2));
   }
 
   throw new Error("Unsupported binop: " + sign);
@@ -131,12 +87,7 @@ export function binopi64(
   c2: StackLocal,
   sign: Sign
 ): StackLocal {
-  return binopLong(c1, c2, sign, function(long: Long): StackLocal {
-    return i64.createValue({
-      high: long.high,
-      low: long.low
-    });
-  });
+  return binop(c1, c2, sign, i64.createValue);
 }
 
 export function binopf32(

--- a/src/interpreter/kernel/instruction/unop.js
+++ b/src/interpreter/kernel/instruction/unop.js
@@ -9,16 +9,16 @@ const f64 = require("../../runtime/values/f64");
 
 // https://webassembly.github.io/spec/core/exec/instructions.html#exec-binop
 function unop(
-  c: StackLocal,
+  { value: c }: StackLocal,
   sign: Sign,
   createValue: number => StackLocal
 ): StackLocal {
   switch (sign) {
     case "abs":
-      return createValue(Math.abs(c.value));
+      return createValue(c.abs());
 
     case "neg":
-      return createValue(-c.value);
+      return createValue(c.neg());
   }
 
   throw new Error("Unsupported unop: " + sign);

--- a/src/interpreter/runtime/castIntoStackLocalOfType.js
+++ b/src/interpreter/runtime/castIntoStackLocalOfType.js
@@ -1,0 +1,22 @@
+// @flow
+const { RuntimeError } = require("../../errors");
+
+const i32 = require("./values/i32");
+const i64 = require("./values/i64");
+const f32 = require("./values/f32");
+const f64 = require("./values/f64");
+
+export function castIntoStackLocalOfType(type: string, v: any): StackLocal {
+  const castFn = {
+    i32: i32.createValueFromAST,
+    i64: i64.createValueFromAST,
+    f32: f32.createValueFromAST,
+    f64: f64.createValueFromAST
+  };
+
+  if (typeof castFn[type] === "undefined") {
+    throw new RuntimeError("Cannot cast: unsupported type " + type);
+  }
+
+  return castFn[type](v);
+}

--- a/src/interpreter/runtime/values/f32.js
+++ b/src/interpreter/runtime/values/f32.js
@@ -1,10 +1,20 @@
 // @flow
+import { BaseNumber } from "./number";
 
 const type = "f32";
 
-export function createValue(value: number): StackLocal {
+export class f32 extends BaseNumber {}
+
+export function createValueFromAST(value: number): StackLocal {
   return {
     type,
-    value: value === 0 ? value : parseFloat(value)
+    value: new f32(value)
+  };
+}
+
+export function createValue(value: f32): StackLocal {
+  return {
+    type,
+    value
   };
 }

--- a/src/interpreter/runtime/values/f64.js
+++ b/src/interpreter/runtime/values/f64.js
@@ -1,10 +1,20 @@
 // @flow
+import { BaseNumber } from "./number";
 
 const type = "f64";
 
-export function createValue(value: number): StackLocal {
+export class f64 extends BaseNumber {}
+
+export function createValueFromAST(value: number): StackLocal {
   return {
     type,
-    value: value === 0 ? value : parseFloat(value)
+    value: new f64(value)
+  };
+}
+
+export function createValue(value: f64): StackLocal {
+  return {
+    type,
+    value
   };
 }

--- a/src/interpreter/runtime/values/i32.js
+++ b/src/interpreter/runtime/values/i32.js
@@ -1,11 +1,21 @@
 // @flow
+import { BaseNumber } from "./number";
 
 const bits = 32;
 const type = "i32";
 
-export function createValue(value: number): StackLocal {
+export class i32 extends BaseNumber {}
+
+export function createValueFromAST(value: number): StackLocal {
   value = (value | 0) % Math.pow(2, bits);
 
+  return {
+    type,
+    value: new i32(value)
+  };
+}
+
+export function createValue(value: i32): StackLocal {
   return {
     type,
     value

--- a/src/interpreter/runtime/values/i64.js
+++ b/src/interpreter/runtime/values/i64.js
@@ -3,9 +3,72 @@ const Long = require("long");
 
 const type = "i64";
 
-export function createValue(value: LongNumber): StackLocal {
+export class i64 implements Number<i64> {
+  _value: Long;
+
+  constructor(value: Long) {
+    this._value = value;
+  }
+
+  add(operand: i64): i64 {
+    return new i64(this._value.add(operand._value));
+  }
+
+  sub(operand: i64): i64 {
+    return new i64(this._value.sub(operand._value));
+  }
+
+  mul(operand: i64): i64 {
+    return new i64(this._value.mul(operand._value));
+  }
+
+  div_s(operand: i64): i64 {
+    return new i64(this._value.div(operand._value));
+  }
+
+  div_u(operand: i64): i64 {
+    return new i64(this._value.div(operand._value));
+  }
+
+  div(operand: i64): i64 {
+    return new i64(this._value.div(operand._value));
+  }
+
+  and(operand: i64): i64 {
+    return new i64(this._value.and(operand._value));
+  }
+
+  or(operand: i64): i64 {
+    return new i64(this._value.or(operand._value));
+  }
+
+  xor(operand: i64): i64 {
+    return new i64(this._value.xor(operand._value));
+  }
+
+  equals(operand: i64): i64 {
+    return this._value.equals(operand._value);
+  }
+
+  isZero(): boolean {
+    return this._value.low == 0 && this._value.high == 0;
+  }
+
+  toNumber(): number {
+    return this._value.toNumber();
+  }
+}
+
+export function createValueFromAST(value: LongNumber): StackLocal {
   return {
     type,
-    value: new Long(value.low, value.high)
+    value: new i64(new Long(value.low, value.high))
+  };
+}
+
+export function createValue(value: i64): StackLocal {
+  return {
+    type,
+    value
   };
 }

--- a/src/interpreter/runtime/values/number.js
+++ b/src/interpreter/runtime/values/number.js
@@ -1,0 +1,83 @@
+// @flow
+
+export class BaseNumber implements Number<BaseNumber> {
+  _value: number;
+
+  constructor(value: number) {
+    this._value = value;
+  }
+
+  add(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value + operand._value);
+  }
+
+  sub(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value - operand._value);
+  }
+
+  mul(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value * operand._value);
+  }
+
+  div_s(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value / operand._value);
+  }
+
+  div_u(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value / operand._value);
+  }
+
+  div(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value / operand._value);
+  }
+
+  and(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value & operand._value);
+  }
+
+  or(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value | operand._value);
+  }
+
+  xor(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(this._value ^ operand._value);
+  }
+
+  isZero() {
+    return this._value == 0;
+  }
+
+  equals(operand: BaseNumber): boolean {
+    return isNaN(this._value)
+      ? isNaN(operand._value)
+      : this._value == operand._value;
+  }
+
+  min(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(Math.min(this._value, operand._value));
+  }
+
+  max(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(Math.max(this._value, operand._value));
+  }
+
+  abs(): BaseNumber {
+    return new BaseNumber(Math.abs(this._value));
+  }
+
+  neg(): BaseNumber {
+    return new BaseNumber(-this._value);
+  }
+
+  copysign(operand: BaseNumber): BaseNumber {
+    return new BaseNumber(
+      Math.sign(this._value) === Math.sign(operand._value)
+        ? this._value
+        : -this._value
+    );
+  }
+
+  toNumber(): number {
+    return this._value;
+  }
+}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -75,6 +75,29 @@ type StackLocal = {
   value: any
 };
 
+interface Number<T> {
+  add(operand: T): T;
+  sub(operand: T): T;
+  mul(operand: T): T;
+  div_s(operand: T): T;
+  div_u(operand: T): T;
+  div(operand: T): T;
+  and(operand: T): T;
+  or(operand: T): T;
+  xor(operand: T): T;
+  min(operand: T): T;
+  max(operand: T): T;
+  copysign(operand: T): T;
+
+  neg(): T;
+  abs(): T;
+
+  isZero(): boolean;
+
+  equals(operand: T): boolean;
+  toNumber(): number;
+}
+
 type Label = {
   arity: number,
   value: any,

--- a/test/interpreter/fixtures/call-func/exec.tjs
+++ b/test/interpreter/fixtures/call-func/exec.tjs
@@ -1,7 +1,8 @@
 const m = WebAssembly.instantiateFromSource(watfmodule);
 
 it("should call a function by its index", () => {
-  assert.equal(m.exports.callByIndex(), 1);
+  const result = m.exports.callByIndex();
+  assert.equal(result, 1);
 });
 
 it("should call a function by its name", () => {

--- a/test/interpreter/kernel/exec/control-instructions.js
+++ b/test/interpreter/kernel/exec/control-instructions.js
@@ -108,7 +108,7 @@ describe("kernel exec - control instruction", () => {
       const stackFrame = createStackFrame(code, []);
       const res = executeStackFrame(stackFrame);
 
-      assert.equal(res.value, 10);
+      assert.equal(res.value.toNumber(), 10);
     });
   });
 
@@ -130,7 +130,7 @@ describe("kernel exec - control instruction", () => {
       const res = executeStackFrame(stackFrame);
 
       assert.typeOf(res, "object");
-      assert.equal(res.value, 2);
+      assert.equal(res.value.toNumber(), 2);
     });
 
     it("should not break if zero", () => {
@@ -151,8 +151,8 @@ describe("kernel exec - control instruction", () => {
       const stackFrame = createStackFrame(code, []);
       const res = executeStackFrame(stackFrame);
 
-      assert.notEqual(res.value, 20);
-      assert.equal(res.value, 1);
+      assert.notEqual(res.value.toNumber(), 20);
+      assert.equal(res.value.toNumber(), 1);
     });
   });
 
@@ -216,7 +216,7 @@ describe("kernel exec - control instruction", () => {
       const stackFrame = createStackFrame(code, []);
       const res = executeStackFrame(stackFrame);
 
-      assert.equal(res.value, 10);
+      assert.equal(res.value.toNumber(), 10);
     });
   });
 });

--- a/test/interpreter/kernel/exec/memory-instructions.js
+++ b/test/interpreter/kernel/exec/memory-instructions.js
@@ -1,7 +1,11 @@
 // @flow
-
 const Long = require("long");
 const { assert } = require("chai");
+
+const { i32 } = require("../../../../lib/interpreter/runtime/values/i32");
+const { i64 } = require("../../../../lib/interpreter/runtime/values/i64");
+const { f32 } = require("../../../../lib/interpreter/runtime/values/f32");
+const { f64 } = require("../../../../lib/interpreter/runtime/values/f64");
 
 const t = require("../../../../lib/compiler/AST");
 const {
@@ -22,7 +26,7 @@ describe("kernel exec - memory instructions", () => {
         t.objectInstruction("const", "i64", [t.numberLiteral("10", "i64")])
       ],
 
-      resEqual: new Long(10, 0)
+      resEqual: new i64(new Long.fromString("10"))
     },
 
     {
@@ -32,7 +36,7 @@ describe("kernel exec - memory instructions", () => {
 
       code: [t.objectInstruction("const", "i32", [t.numberLiteral(10)])],
 
-      resEqual: 10
+      resEqual: new i32(new Long.fromString("10"))
     },
 
     {
@@ -42,7 +46,7 @@ describe("kernel exec - memory instructions", () => {
 
       code: [t.objectInstruction("const", "f32", [t.numberLiteral(10.0)])],
 
-      resEqual: 10.0
+      resEqual: new f32(10.0)
     },
 
     {
@@ -52,7 +56,7 @@ describe("kernel exec - memory instructions", () => {
 
       code: [t.objectInstruction("const", "f64", [t.numberLiteral(10.0)])],
 
-      resEqual: 10.0
+      resEqual: new f64(10.0)
     },
 
     {
@@ -68,7 +72,7 @@ describe("kernel exec - memory instructions", () => {
         t.instruction("get_local", [t.numberLiteral(0)])
       ],
 
-      resEqual: 10
+      resEqual: new i32(10)
     },
 
     {
@@ -83,7 +87,7 @@ describe("kernel exec - memory instructions", () => {
         ])
       ],
 
-      resEqual: 2
+      resEqual: new i32(2)
     }
   ];
 
@@ -96,11 +100,7 @@ describe("kernel exec - memory instructions", () => {
         throw new Error("No result");
       }
 
-      if (res.value instanceof Long) {
-        assert.isTrue(res.value.equals(op.resEqual));
-      } else {
-        assert.equal(res.value, op.resEqual);
-      }
+      assert.isTrue(res.value.equals(op.resEqual));
     });
   });
 });

--- a/test/interpreter/kernel/exec/numeric-instructions.js
+++ b/test/interpreter/kernel/exec/numeric-instructions.js
@@ -2,6 +2,13 @@
 const Long = require("long");
 const { assert } = require("chai");
 
+const { i32 } = require("../../../../lib/interpreter/runtime/values/i32");
+const { i64 } = require("../../../../lib/interpreter/runtime/values/i64");
+const { f32 } = require("../../../../lib/interpreter/runtime/values/f32");
+const { f64 } = require("../../../../lib/interpreter/runtime/values/f64");
+const {
+  castIntoStackLocalOfType
+} = require("../../../../lib/interpreter/runtime/castIntoStackLocalOfType");
 const t = require("../../../../lib/compiler/AST");
 const {
   executeStackFrame
@@ -27,7 +34,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("add", "i32")
       ],
 
-      resEqual: 2
+      resEqual: new i32(2)
     },
 
     {
@@ -41,7 +48,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("sub", "i32")
       ],
 
-      resEqual: 0
+      resEqual: new i32(0)
     },
 
     {
@@ -55,7 +62,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("mul", "i32")
       ],
 
-      resEqual: 2
+      resEqual: new i32(2)
     },
 
     {
@@ -69,7 +76,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("div_s", "i32")
       ],
 
-      resEqual: 5
+      resEqual: new i32(5)
     },
 
     {
@@ -83,7 +90,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("div_u", "i32")
       ],
 
-      resEqual: 5
+      resEqual: new i32(5)
     },
 
     /**
@@ -104,7 +111,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("and", "i64")
       ],
 
-      resEqual: Long.fromString("10001001010010", false, 2)
+      resEqual: new i64(Long.fromString("10001001010010", false, 2))
     },
 
     {
@@ -121,7 +128,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("or", "i64")
       ],
 
-      resEqual: Long.fromString("10001011110010", false, 2)
+      resEqual: new i64(Long.fromString("10001011110010", false, 2))
     },
 
     {
@@ -138,7 +145,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("xor", "i64")
       ],
 
-      resEqual: Long.fromString("00000010100000", false, 2)
+      resEqual: new i64(Long.fromString("00000010100000", false, 2))
     },
 
     {
@@ -155,7 +162,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("add", "i64")
       ],
 
-      resEqual: Long.fromString("1844674407370955162")
+      resEqual: new i64(Long.fromString("1844674407370955162"))
     },
 
     {
@@ -172,7 +179,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("sub", "i64")
       ],
 
-      resEqual: Long.fromString("1844674407370955160")
+      resEqual: new i64(Long.fromString("1844674407370955160"))
     },
 
     {
@@ -189,7 +196,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("mul", "i64")
       ],
 
-      resEqual: Long.fromString("3689348814741910322")
+      resEqual: new i64(Long.fromString("3689348814741910322"))
     },
 
     {
@@ -206,7 +213,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("div_s", "i64")
       ],
 
-      resEqual: Long.fromString("922337203685477580")
+      resEqual: new i64(Long.fromString("922337203685477580"))
     },
 
     {
@@ -223,7 +230,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("div_u", "i64")
       ],
 
-      resEqual: Long.fromString("922337203685477580")
+      resEqual: new i64(Long.fromString("922337203685477580"))
     },
 
     /**
@@ -241,7 +248,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("add", "f32")
       ],
 
-      resEqual: 2
+      resEqual: new f32(2)
     },
 
     {
@@ -255,7 +262,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("sub", "f32")
       ],
 
-      resEqual: 0
+      resEqual: new f32(0)
     },
 
     {
@@ -269,7 +276,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("mul", "f32")
       ],
 
-      resEqual: 2
+      resEqual: new f32(2)
     },
 
     {
@@ -283,7 +290,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("div", "f32")
       ],
 
-      resEqual: 5.0
+      resEqual: new f32(5.0)
     },
 
     {
@@ -297,7 +304,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f32")
       ],
 
-      resEqual: 5.0
+      resEqual: new f32(5.0)
     },
 
     {
@@ -311,7 +318,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f32")
       ],
 
-      resEqual: -0
+      resEqual: new f32(-0)
     },
 
     {
@@ -328,7 +335,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f32")
       ],
 
-      resEqual: -Infinity
+      resEqual: new f32(-Infinity)
     },
 
     {
@@ -342,7 +349,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f32")
       ],
 
-      resEqual: 1234
+      resEqual: new f32(1234)
     },
 
     {
@@ -356,7 +363,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f32")
       ],
 
-      resEqual: NaN
+      resEqual: new f32(NaN)
     },
 
     {
@@ -373,7 +380,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f32")
       ],
 
-      resEqual: 0.00000000000000000000000001
+      resEqual: new f32(0.00000000000000000000000001)
     },
 
     {
@@ -387,7 +394,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f32")
       ],
 
-      resEqual: 1000.7
+      resEqual: new f32(1000.7)
     },
 
     {
@@ -401,7 +408,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f32")
       ],
 
-      resEqual: +0
+      resEqual: new f32(+0)
     },
 
     {
@@ -418,7 +425,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f32")
       ],
 
-      resEqual: Infinity
+      resEqual: new f32(Infinity)
     },
 
     {
@@ -432,7 +439,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f32")
       ],
 
-      resEqual: Infinity
+      resEqual: new f32(Infinity)
     },
 
     {
@@ -446,7 +453,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f32")
       ],
 
-      resEqual: NaN
+      resEqual: new f32(NaN)
     },
 
     {
@@ -463,7 +470,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f32")
       ],
 
-      resEqual: 0.0000000000000000000000001
+      resEqual: new f32(0.0000000000000000000000001)
     },
 
     /**
@@ -481,7 +488,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("add", "f64")
       ],
 
-      resEqual: 2.0
+      resEqual: new f64(2.0)
     },
 
     {
@@ -495,7 +502,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("sub", "f64")
       ],
 
-      resEqual: 0
+      resEqual: new f64(0)
     },
 
     {
@@ -509,7 +516,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("mul", "f64")
       ],
 
-      resEqual: 2.0
+      resEqual: new f64(2.0)
     },
 
     {
@@ -523,7 +530,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("div", "f64")
       ],
 
-      resEqual: 5.0
+      resEqual: new f64(5.0)
     },
 
     {
@@ -537,7 +544,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f64")
       ],
 
-      resEqual: 5.0
+      resEqual: new f64(5.0)
     },
 
     {
@@ -551,7 +558,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f64")
       ],
 
-      resEqual: -0
+      resEqual: new f64(-0)
     },
 
     {
@@ -568,7 +575,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f64")
       ],
 
-      resEqual: -Infinity
+      resEqual: new f64(-Infinity)
     },
 
     {
@@ -582,7 +589,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f64")
       ],
 
-      resEqual: 1234
+      resEqual: new f64(1234)
     },
 
     {
@@ -596,7 +603,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f64")
       ],
 
-      resEqual: NaN
+      resEqual: new f64(NaN)
     },
 
     {
@@ -613,7 +620,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("min", "f64")
       ],
 
-      resEqual: 0.00000000000000000000000001
+      resEqual: new f64(0.00000000000000000000000001)
     },
 
     {
@@ -627,7 +634,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f64")
       ],
 
-      resEqual: 1000.7
+      resEqual: new f64(1000.7)
     },
 
     {
@@ -641,7 +648,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f64")
       ],
 
-      resEqual: +0
+      resEqual: new f64(+0)
     },
 
     {
@@ -658,7 +665,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f64")
       ],
 
-      resEqual: Infinity
+      resEqual: new f64(Infinity)
     },
 
     {
@@ -672,7 +679,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f64")
       ],
 
-      resEqual: Infinity
+      resEqual: new f64(Infinity)
     },
 
     {
@@ -686,7 +693,7 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f64")
       ],
 
-      resEqual: NaN
+      resEqual: new f64(NaN)
     },
 
     {
@@ -703,21 +710,21 @@ describe("kernel exec - numeric instructions", () => {
         t.objectInstruction("max", "f64")
       ],
 
-      resEqual: 0.0000000000000000000000001
+      resEqual: new f64(0.0000000000000000000000001)
     }
   ];
 
   operations.forEach(op => {
     describe(op.name, () => {
       it("should get the correct result", () => {
-        const stackFrame = createStackFrame(op.code, op.args);
-        const res = executeStackFrame(stackFrame).value;
+        const args = op.args.map(({ value, type }) =>
+          castIntoStackLocalOfType(type, value)
+        );
 
-        if (res.value instanceof Long) {
-          assert.isTrue(res.value.equals(op.resEqual));
-        } else {
-          assert.deepEqual(res, op.resEqual);
-        }
+        const stackFrame = createStackFrame(op.code, args);
+        const res = executeStackFrame(stackFrame);
+
+        assert.isTrue(res.value.equals(op.resEqual));
       });
 
       it("should assert validations - 1 missing arg", () => {

--- a/test/interpreter/kernel/exec/parametric-instructions.js
+++ b/test/interpreter/kernel/exec/parametric-instructions.js
@@ -2,6 +2,7 @@
 
 const { assert } = require("chai");
 
+const { i32 } = require("../../../../lib/interpreter/runtime/values/i32");
 const t = require("../../../../lib/compiler/AST");
 const {
   executeStackFrame
@@ -23,7 +24,7 @@ describe("kernel exec - parametric instructions", () => {
         t.instruction("drop", [])
       ],
 
-      resEqual: 1
+      resEqual: new i32(1)
     }
   ];
 
@@ -36,7 +37,7 @@ describe("kernel exec - parametric instructions", () => {
         throw new Error("No result");
       }
 
-      assert.equal(res.value, op.resEqual);
+      assert.isTrue(res.value.equals(op.resEqual));
     });
   });
 

--- a/test/interpreter/runtime/values.js
+++ b/test/interpreter/runtime/values.js
@@ -94,42 +94,42 @@ describe("module create interface", () => {
 
   describe("integer 32bits", () => {
     it("createValue should return the correct value", () => {
-      const v = i32.createValue(1);
+      const v = i32.createValueFromAST(1);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1);
+      assert.equal(v.value.toNumber(), 1);
       assert.equal(v.type, "i32");
     });
 
     it("createValue should overflow and result to 1", () => {
-      const v = i32.createValue(Math.pow(2, 32) + 1);
+      const v = i32.createValueFromAST(Math.pow(2, 32) + 1);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1);
+      assert.equal(v.value.toNumber(), 1);
       assert.equal(v.type, "i32");
     });
 
     it("createValue should return an int from a float", () => {
-      const v = i32.createValue(1.1);
+      const v = i32.createValueFromAST(1.1);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1);
+      assert.equal(v.value.toNumber(), 1);
       assert.equal(v.type, "i32");
     });
   });
 
   describe("integer 64bits", () => {
     it("createValue should return the correct value", () => {
-      const v = i64.createValue({
+      const v = i64.createValueFromAST({
         high: 0,
         low: 1
       });
@@ -138,56 +138,56 @@ describe("module create interface", () => {
       assert.typeOf(v.type, "string");
       assert.typeOf(v.value, "object");
 
-      assert.equal(v.value.high, 0);
-      assert.equal(v.value.low, 1);
+      assert.equal(v.value._value.high, 0);
+      assert.equal(v.value._value.low, 1);
       assert.equal(v.type, "i64");
     });
   });
 
   describe("float 32bits", () => {
     it("createValue should return a float", () => {
-      const v = f32.createValue(1.0);
+      const v = f32.createValueFromAST(1.0);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1.0);
+      assert.equal(v.value.toNumber(), 1.0);
       assert.equal(v.type, "f32");
     });
 
     it("createValue should return a float from a int", () => {
-      const v = f32.createValue(1);
+      const v = f32.createValueFromAST(1);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1.0);
+      assert.equal(v.value.toNumber(), 1.0);
       assert.equal(v.type, "f32");
     });
   });
 
   describe("float 64bits", () => {
     it("createValue should return a float", () => {
-      const v = f64.createValue(1.0);
+      const v = f64.createValueFromAST(1.0);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1.0);
+      assert.equal(v.value.toNumber(), 1.0);
       assert.equal(v.type, "f64");
     });
 
     it("createValue should return a float from a int", () => {
-      const v = f64.createValue(1);
+      const v = f64.createValueFromAST(1);
 
       assert.typeOf(v, "object");
       assert.typeOf(v.type, "string");
-      assert.typeOf(v.value, "number");
+      assert.typeOf(v.value._value, "number");
 
-      assert.equal(v.value, 1.0);
+      assert.equal(v.value.toNumber(), 1.0);
       assert.equal(v.type, "f64");
     });
   });
@@ -228,7 +228,7 @@ describe("module create interface", () => {
 
       assert.typeOf(instance, "object");
       assert.equal(instance.mutability, "const");
-      assert.equal(instance.value, 10);
+      assert.equal(instance.value.toNumber(), 10);
     });
   });
 


### PR DESCRIPTION
As discussed in a few recent PRs, e.g. #85, there might be some advantage to wrapping numbers are runtime. I've had a go at fixing #87 - but rather than take the easy route, have added a wrapper, then used that to apply the fix.

(please ignore the few failing tests, I wanted to get some feedback before completing this work).

The key changes are:

1. The creation of a [`Number<T>`](https://github.com/xtuc/js-webassembly-interpreter/pull/90/files#diff-fbd62d0fcf47917ebaa26c8676245ae4R78) interface. All numeric values, within `StackLocal` are implementations of this interface
2. There are currently two implementations of this interface, `BaseNumber`, which is subclassed and used by i32, f32, f64 - this uses `number` as the underlying storage. The other is `i64` which uses long.js for storage
3. This simplifies the binop code, where previously [i64 was a special case](https://github.com/xtuc/js-webassembly-interpreter/compare/master...ColinEberhardt:division-fix?expand=1#diff-68f59886a8a2af3660e543e0cc5c82ddL134).
4. Arguments passed to exported functions, and the results returned by exported functions now need wrapping / unwrapping

The div_s fix for i32 is [implemented in a BaseNumber subclass](https://github.com/xtuc/js-webassembly-interpreter/compare/master...ColinEberhardt:division-fix?expand=1#diff-240519ffcef869736d1f065ee0cf3f6fR12)

I like that this ...
 - Hides our use of long.js behind a wrapper, minimising code that is directly exposed to this external code
 - The BaseNumber subclasses could throw exceptions for unsupported operations.

For the floating point handling of NaN, this can now be implemented as a BaseNumber subclass.

I dislike that ...
 - this adds a lot of extra wrapping / unwrapping. Not a performance concern, I benchmarked before and after, and didn't see a significant change. It's more the code complexity that I worry about
  - ... although, this is mostly an impact on the tests, so perhaps not a big concern?
 - I think this makes the `type` property of StackLocal redundant? if so, should `StackLocal` still exist?

Anyhow, would be good to get some feedback on this before I do any more.
