### PR TITLE
implemented f32 / f64 reinterpret

### DIFF
--- a/src/interpreter/kernel/instruction/unop.js
+++ b/src/interpreter/kernel/instruction/unop.js
@@ -1,6 +1,14 @@
 // @flow
 
-type Sign = "abs" | "neg" | "clz" | "ctz" | "popcnt" | "eqz";
+type Sign =
+  | "abs"
+  | "neg"
+  | "clz"
+  | "ctz"
+  | "popcnt"
+  | "eqz"
+  | "reinterpret/f32"
+  | "reinterpret/f64";
 
 import * as i32 from "../../runtime/values/i32";
 import * as i64 from "../../runtime/values/i64";
@@ -31,6 +39,12 @@ function unop(
 
     case "eqz":
       return createValue(value.eqz());
+
+    case "reinterpret/f32":
+      return i32.createValue(value.reinterpret());
+
+    case "reinterpret/f64":
+      return i64.createValue(value.reinterpret());
   }
 
   throw new Error("Unsupported unop: " + sign);

--- a/src/interpreter/kernel/instruction/unop.js
+++ b/src/interpreter/kernel/instruction/unop.js
@@ -1,6 +1,6 @@
 // @flow
 
-type Sign =
+type Operation =
   | "abs"
   | "neg"
   | "clz"
@@ -18,10 +18,10 @@ import * as f64 from "../../runtime/values/f64";
 // https://webassembly.github.io/spec/core/exec/instructions.html#exec-binop
 function unop(
   { value: value }: StackLocal,
-  sign: Sign,
+  operation: Operation,
   createValue: any => StackLocal
 ): StackLocal {
-  switch (sign) {
+  switch (operation) {
     case "abs":
       return createValue(value.abs());
 
@@ -50,18 +50,18 @@ function unop(
   throw new Error("Unsupported unop: " + sign);
 }
 
-export function unopi32(c: StackLocal, sign: Sign): StackLocal {
-  return unop(c, sign, i32.createValue);
+export function unopi32(c: StackLocal, operation: Operation): StackLocal {
+  return unop(c, operation, i32.createValue);
 }
 
-export function unopi64(c: StackLocal, sign: Sign): StackLocal {
-  return unop(c, sign, i64.createValue);
+export function unopi64(c: StackLocal, operation: Operation): StackLocal {
+  return unop(c, operation, i64.createValue);
 }
 
-export function unopf32(c: StackLocal, sign: Sign): StackLocal {
-  return unop(c, sign, f32.createValue);
+export function unopf32(c: StackLocal, operation: Operation): StackLocal {
+  return unop(c, operation, f32.createValue);
 }
 
-export function unopf64(c: StackLocal, sign: Sign): StackLocal {
-  return unop(c, sign, f64.createValue);
+export function unopf64(c: StackLocal, operation: Operation): StackLocal {
+  return unop(c, operation, f64.createValue);
 }

--- a/src/interpreter/kernel/instruction/unop.js
+++ b/src/interpreter/kernel/instruction/unop.js
@@ -47,7 +47,7 @@ function unop(
       return i64.createValue(value.reinterpret());
   }
 
-  throw new Error("Unsupported unop: " + sign);
+  throw new Error("Unsupported unop: " + operation);
 }
 
 export function unopi32(c: StackLocal, operation: Operation): StackLocal {

--- a/src/interpreter/runtime/values/f32.js
+++ b/src/interpreter/runtime/values/f32.js
@@ -1,9 +1,17 @@
 // @flow
-import { BaseNumber } from "./number";
+import { Float } from "./number";
+import { i32 } from "./i32";
 
 const type = "f32";
 
-export class f32 extends BaseNumber {
+export class f32 extends Float<i32> {
+  reinterpret(): i32 {
+    const floatArray = new Float32Array(1);
+    floatArray[0] = this._value;
+    const intArray = new Int32Array(floatArray.buffer);
+    return new i32(intArray[0]);
+  }
+
   add(operand: f32): f32 {
     // If the other operand is a nan we use its implementation, otherwise the BaseNumber one.
     return operand instanceof f32nan

--- a/src/interpreter/runtime/values/f32.js
+++ b/src/interpreter/runtime/values/f32.js
@@ -13,31 +13,31 @@ export class f32 extends Float<i32> {
   }
 
   add(operand: f32): f32 {
-    // If the other operand is a nan we use its implementation, otherwise the BaseNumber one.
+    // If the other operand is a nan we use its implementation, otherwise the Float one.
     return operand instanceof f32nan
       ? operand.add(this)
-      : BaseNumber.prototype.add.call(this, operand);
+      : Float.prototype.add.call(this, operand);
   }
 
   sub(operand: f32): f32 {
-    // If the other operand is a nan we use its implementation, otherwise the BaseNumber one.
+    // If the other operand is a nan we use its implementation, otherwise the Float one.
     return operand instanceof f32nan
       ? operand.sub(this)
-      : BaseNumber.prototype.sub.call(this, operand);
+      : Float.prototype.sub.call(this, operand);
   }
 
   mul(operand: f32): f32 {
-    // If the other operand is a nan we use its implementation, otherwise the BaseNumber one.
+    // If the other operand is a nan we use its implementation, otherwise the Float one.
     return operand instanceof f32nan
       ? operand.mul(this)
-      : BaseNumber.prototype.mul.call(this, operand);
+      : Float.prototype.mul.call(this, operand);
   }
 
   div(operand: f32): f32 {
-    // If the other operand is a nan we use its implementation, otherwise the BaseNumber one.
+    // If the other operand is a nan we use its implementation, otherwise the Float one.
     return operand instanceof f32nan
       ? operand.div(this)
-      : BaseNumber.prototype.div.call(this, operand);
+      : Float.prototype.div.call(this, operand);
   }
 }
 

--- a/src/interpreter/runtime/values/f64.js
+++ b/src/interpreter/runtime/values/f64.js
@@ -1,9 +1,20 @@
 // @flow
-import { BaseNumber } from "./number";
+import Long from "long";
+
+import { Float } from "./number";
+import { i64 } from "./i64";
 
 const type = "f64";
 
-export class f64 extends BaseNumber {}
+export class f64 extends Float<i64> {
+  reinterpret(): i64 {
+    const floatArray = new Float64Array(1);
+    floatArray[0] = this._value;
+    const lowIntArray = new Int32Array(floatArray.buffer.slice(0, 4));
+    const highIntArray = new Int32Array(floatArray.buffer.slice(4, 8));
+    return new i64(Long.fromBits(lowIntArray[0], highIntArray[0]));
+  }
+}
 
 export function createValueFromAST(value: number): StackLocal {
   return {

--- a/src/interpreter/runtime/values/i32.js
+++ b/src/interpreter/runtime/values/i32.js
@@ -11,7 +11,7 @@ const type = "i32";
 // this function performs the inverse
 const toUnsigned = a => a >>> 0;
 
-export class i32 implements NumberInterface<i32> {
+export class i32 implements IntegerValue<i32> {
   _value: number;
 
   constructor(value: number) {
@@ -267,6 +267,10 @@ export class i32 implements NumberInterface<i32> {
   isTrue(): boolean {
     // https://webassembly.github.io/spec/core/exec/numerics.html#boolean-interpretation
     return this._value == 1;
+  }
+
+  toString(): string {
+    return this._value.toString();
   }
 }
 

--- a/src/interpreter/runtime/values/i32.js
+++ b/src/interpreter/runtime/values/i32.js
@@ -268,10 +268,6 @@ export class i32 implements IntegerValue<i32> {
     // https://webassembly.github.io/spec/core/exec/numerics.html#boolean-interpretation
     return this._value == 1;
   }
-
-  toString(): string {
-    return this._value.toString();
-  }
 }
 
 export function createValueFromAST(value: number): StackLocal {

--- a/src/interpreter/runtime/values/i64.js
+++ b/src/interpreter/runtime/values/i64.js
@@ -1,11 +1,11 @@
 // @flow
-const Long = require("long");
+import Long from "long";
 
 import { RuntimeError } from "../../../errors";
 
 const type = "i64";
 
-export class i64 implements NumberInterface<i64> {
+export class i64 implements IntegerValue<i64> {
   _value: Long;
 
   constructor(value: Long) {

--- a/src/interpreter/runtime/values/number.js
+++ b/src/interpreter/runtime/values/number.js
@@ -1,165 +1,85 @@
-// @flow
 import { RuntimeError } from "../../../errors";
 
-export class BaseNumber implements NumberInterface<BaseNumber> {
+// @flow
+export class Float<U> implements FloatingPointValue<Float<U>, U> {
   _value: number;
 
   constructor(value: number) {
     this._value = value;
   }
 
-  add(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value + operand._value);
+  add(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value + operand._value);
   }
 
-  sub(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value - operand._value);
+  sub(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value - operand._value);
   }
 
-  mul(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value * operand._value);
+  mul(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value * operand._value);
   }
 
-  div_s(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value / operand._value);
+  div_s(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value / operand._value);
   }
 
-  div_u(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value / operand._value);
+  div_u(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value / operand._value);
   }
 
-  div(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value / operand._value);
+  div(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value / operand._value);
   }
 
-  and(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value & operand._value);
+  and(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value & operand._value);
   }
 
-  or(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value | operand._value);
+  or(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value | operand._value);
   }
 
-  xor(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(this._value ^ operand._value);
+  xor(operand: Float<U>): Float<U> {
+    return new this.constructor(this._value ^ operand._value);
   }
 
   isZero() {
     return this._value == 0;
   }
 
-  equals(operand: BaseNumber): boolean {
+  equals(operand: Float<U>): boolean {
     return isNaN(this._value)
       ? isNaN(operand._value)
       : this._value == operand._value;
   }
 
-  min(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(Math.min(this._value, operand._value));
+  min(operand: Float<U>): Float<U> {
+    return new this.constructor(Math.min(this._value, operand._value));
   }
 
-  max(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(Math.max(this._value, operand._value));
+  max(operand: Float<U>): Float<U> {
+    return new this.constructor(Math.max(this._value, operand._value));
   }
 
-  abs(): BaseNumber {
-    return new BaseNumber(Math.abs(this._value));
+  abs(): Float<U> {
+    return new this.constructor(Math.abs(this._value));
   }
 
-  neg(): BaseNumber {
-    return new BaseNumber(-this._value);
+  neg(): Float<U> {
+    return new this.constructor(-this._value);
   }
 
-  rem_s(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  rem_u(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  shl(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  shr_s(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  shr_u(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  rotl(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  rotr(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  eq(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  ne(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  lt_s(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  lt_u(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  le_s(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  le_u(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  gt_s(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  gt_u(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  ge_s(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  ge_u(/* operand: BaseNumber */): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  clz(): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  ctz(): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  eqz(): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  popcnt(): BaseNumber {
-    throw new RuntimeError("Unsupported operation");
-  }
-
-  copysign(operand: BaseNumber): BaseNumber {
-    return new BaseNumber(
+  copysign(operand: Float<U>): Float<U> {
+    return new this.constructor(
       Math.sign(this._value) === Math.sign(operand._value)
         ? this._value
         : -this._value
     );
+  }
+
+  reinterpret(): U {
+    throw new RuntimeError("unsupported operation");
   }
 
   toNumber(): number {
@@ -168,5 +88,9 @@ export class BaseNumber implements NumberInterface<BaseNumber> {
 
   isTrue(): boolean {
     return this._value == 1;
+  }
+
+  toString(): string {
+    return this._value.toString();
   }
 }

--- a/src/types/AST.js
+++ b/src/types/AST.js
@@ -3,7 +3,7 @@
 import type { i32 } from "../interpreter/runtime/values/i32";
 
 type U32Literal = NumberLiteral & {
-  value: NumberInterface<i32>
+  value: NumericOperations<i32>
 };
 
 type Typeidx = U32Literal;

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -75,10 +75,7 @@ type StackLocal = {
   value: any
 };
 
-interface NumberInterface<T> {
-  add(operand: T): T;
-  sub(operand: T): T;
-  mul(operand: T): T;
+interface IntegerValue<T> extends NumericOperations<T> {
   div_s(operand: T): T;
   div_u(operand: T): T;
   rem_s(operand: T): T;
@@ -88,13 +85,9 @@ interface NumberInterface<T> {
   shr_u(operand: T): T;
   rotl(operand: T): T;
   rotr(operand: T): T;
-  div(operand: T): T;
   and(operand: T): T;
   or(operand: T): T;
   xor(operand: T): T;
-  min(operand: T): T;
-  max(operand: T): T;
-  copysign(operand: T): T;
   eq(operand: T): T;
   ne(operand: T): T;
   lt_s(operand: T): T;
@@ -105,18 +98,30 @@ interface NumberInterface<T> {
   gt_u(operand: T): T;
   ge_s(operand: T): T;
   ge_u(operand: T): T;
-
-  neg(): T;
-  abs(): T;
   clz(): T;
-  ctz(): T;
   popcnt(): T;
   eqz(): T;
+}
 
+interface FloatingPointValue<T, U> extends NumericOperations<T> {
+  min(operand: T): T;
+  max(operand: T): T;
+  copysign(operand: T): T;
+  neg(): T;
+  abs(): T;
+  reinterpret(): U;
+}
+
+interface NumericOperations<T> {
+  add(operand: T): T;
+  sub(operand: T): T;
+  mul(operand: T): T;
+  div(operand: T): T;
   equals(operand: T): boolean;
   toNumber(): number;
   toString(): string;
   isTrue(): boolean;
+  toString(): string;
 }
 
 type Label = {

--- a/test/interpreter/fixtures/conversions/exec.tjs
+++ b/test/interpreter/fixtures/conversions/exec.tjs
@@ -1,0 +1,459 @@
+const parseFloat = require("webassembly-floating-point-hex-parser");
+
+const m = WebAssembly.instantiateFromSource(watfmodule);
+
+// \(assert_return \(invoke "([fi][0-9]{2})\.([0-9a-z_.]*)" \([fi][0-9]{2}\.const ([^)]*)\)\) \([fi][0-9]{2}\.const ([+.:0-9xa-z-]*)\)\)
+// equals("$2_$1", "$3", "$4");
+
+it("should conform to the wasm test suite", () => {
+  const equals = (exportFunction, inputString, expectedOutputString) => {
+    // optionally parse the input as floating point hex
+    const input =
+      inputString.indexOf("x") !== -1
+        ? parseFloat(inputString)
+        : Number(inputString);
+
+    // the WebAssembly test suite assert values are unsigned integer values. The JS <=> WASM boundary
+    // converts these into signed values. Here we perform the required conversion so that we can use the
+    // same expected value in our tests.
+    const expectedOutput = Number(expectedOutputString) | 0;
+
+    // verify
+    const result = m.exports[exportFunction](input);
+    assert.equal(result, expectedOutput);
+  };
+
+  //   equals("extend_s_i32_i64", "0", "0");
+  // equals("extend_s_i32_i64", "10000", "10000");
+  // equals("extend_s_i32_i64", "-10000", "-10000");
+  // equals("extend_s_i32_i64", "-1", "-1");
+  // equals("extend_s_i32_i64", "0x7fffffff", "0x000000007fffffff");
+  // equals("extend_s_i32_i64", "0x80000000", "0xffffffff80000000");
+
+  // equals("extend_u_i32_i64", "0", "0");
+  // equals("extend_u_i32_i64", "10000", "10000");
+  // equals("extend_u_i32_i64", "-10000", "0x00000000ffffd8f0");
+  // equals("extend_u_i32_i64", "-1", "0xffffffff");
+  // equals("extend_u_i32_i64", "0x7fffffff", "0x000000007fffffff");
+  // equals("extend_u_i32_i64", "0x80000000", "0x0000000080000000");
+
+  // equals("wrap_i64_i32", "-1", "-1");
+  // equals("wrap_i64_i32", "-100000", "-100000");
+  // equals("wrap_i64_i32", "0x80000000", "0x80000000");
+  // equals("wrap_i64_i32", "0xffffffff7fffffff", "0x7fffffff");
+  // equals("wrap_i64_i32", "0xffffffff00000000", "0x00000000");
+  // equals("wrap_i64_i32", "0xfffffffeffffffff", "0xffffffff");
+  // equals("wrap_i64_i32", "0xffffffff00000001", "0x00000001");
+  // equals("wrap_i64_i32", "0", "0");
+  // equals("wrap_i64_i32", "1311768467463790320", "0x9abcdef0");
+  // equals("wrap_i64_i32", "0x00000000ffffffff", "0xffffffff");
+  // equals("wrap_i64_i32", "0x0000000100000000", "0x00000000");
+  // equals("wrap_i64_i32", "0x0000000100000001", "0x00000001");
+
+  // equals("trunc_s_f32_i32", "0.0", "0");
+  // equals("trunc_s_f32_i32", "-0.0", "0");
+  // equals("trunc_s_f32_i32", "0x1p-149", "0");
+  // equals("trunc_s_f32_i32", "-0x1p-149", "0");
+  // equals("trunc_s_f32_i32", "1.0", "1");
+  // equals("trunc_s_f32_i32", "0x1.19999ap+0", "1");
+  // equals("trunc_s_f32_i32", "1.5", "1");
+  // equals("trunc_s_f32_i32", "-1.0", "-1");
+  // equals("trunc_s_f32_i32", "-0x1.19999ap+0", "-1");
+  // equals("trunc_s_f32_i32", "-1.5", "-1");
+  // equals("trunc_s_f32_i32", "-1.9", "-1");
+  // equals("trunc_s_f32_i32", "-2.0", "-2");
+  // equals("trunc_s_f32_i32", "2147483520.0", "2147483520");
+  // equals("trunc_s_f32_i32", "-2147483648.0", "-2147483648");
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const 2147483648.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const -2147483904.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const nan:0x200000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_s_f32" (f32.const -nan:0x200000)) "invalid conversion to integer")
+
+  // equals("trunc_u_f32_i32", "0.0", "0");
+  // equals("trunc_u_f32_i32", "-0.0", "0");
+  // equals("trunc_u_f32_i32", "0x1p-149", "0");
+  // equals("trunc_u_f32_i32", "-0x1p-149", "0");
+  // equals("trunc_u_f32_i32", "1.0", "1");
+  // equals("trunc_u_f32_i32", "0x1.19999ap+0", "1");
+  // equals("trunc_u_f32_i32", "1.5", "1");
+  // equals("trunc_u_f32_i32", "1.9", "1");
+  // equals("trunc_u_f32_i32", "2.0", "2");
+  // equals("trunc_u_f32_i32", "2147483648", "-2147483648"); ;; 0x1.00000p+31 -> 8000 0000
+  // equals("trunc_u_f32_i32", "4294967040.0", "-256");
+  // equals("trunc_u_f32_i32", "-0x1.ccccccp-1", "0");
+  // equals("trunc_u_f32_i32", "-0x1.fffffep-1", "0");
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const 4294967296.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const -1.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const nan:0x200000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_u_f32" (f32.const -nan:0x200000)) "invalid conversion to integer")
+
+  // equals("trunc_s_f64_i32", "0.0", "0");
+  // equals("trunc_s_f64_i32", "-0.0", "0");
+  // equals("trunc_s_f64_i32", "0x0.0000000000001p-1022", "0");
+  // equals("trunc_s_f64_i32", "-0x0.0000000000001p-1022", "0");
+  // equals("trunc_s_f64_i32", "1.0", "1");
+  // equals("trunc_s_f64_i32", "0x1.199999999999ap+0", "1");
+  // equals("trunc_s_f64_i32", "1.5", "1");
+  // equals("trunc_s_f64_i32", "-1.0", "-1");
+  // equals("trunc_s_f64_i32", "-0x1.199999999999ap+0", "-1");
+  // equals("trunc_s_f64_i32", "-1.5", "-1");
+  // equals("trunc_s_f64_i32", "-1.9", "-1");
+  // equals("trunc_s_f64_i32", "-2.0", "-2");
+  // equals("trunc_s_f64_i32", "2147483647.0", "2147483647");
+  // equals("trunc_s_f64_i32", "-2147483648.0", "-2147483648");
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const 2147483648.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const -2147483649.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const nan:0x4000000000000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_s_f64" (f64.const -nan:0x4000000000000)) "invalid conversion to integer")
+
+  // equals("trunc_u_f64_i32", "0.0", "0");
+  // equals("trunc_u_f64_i32", "-0.0", "0");
+  // equals("trunc_u_f64_i32", "0x0.0000000000001p-1022", "0");
+  // equals("trunc_u_f64_i32", "-0x0.0000000000001p-1022", "0");
+  // equals("trunc_u_f64_i32", "1.0", "1");
+  // equals("trunc_u_f64_i32", "0x1.199999999999ap+0", "1");
+  // equals("trunc_u_f64_i32", "1.5", "1");
+  // equals("trunc_u_f64_i32", "1.9", "1");
+  // equals("trunc_u_f64_i32", "2.0", "2");
+  // equals("trunc_u_f64_i32", "2147483648", "-2147483648"); ;; 0x1.00000p+31 -> 8000 0000
+  // equals("trunc_u_f64_i32", "4294967295.0", "-1");
+  // equals("trunc_u_f64_i32", "-0x1.ccccccccccccdp-1", "0");
+  // equals("trunc_u_f64_i32", "-0x1.fffffffffffffp-1", "0");
+  // equals("trunc_u_f64_i32", "1e8", "100000000");
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const 4294967296.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const -1.0)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const 1e16)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const 1e30)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const 9223372036854775808)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const nan:0x4000000000000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i32.trunc_u_f64" (f64.const -nan:0x4000000000000)) "invalid conversion to integer")
+
+  // equals("trunc_s_f32_i64", "0.0", "0");
+  // equals("trunc_s_f32_i64", "-0.0", "0");
+  // equals("trunc_s_f32_i64", "0x1p-149", "0");
+  // equals("trunc_s_f32_i64", "-0x1p-149", "0");
+  // equals("trunc_s_f32_i64", "1.0", "1");
+  // equals("trunc_s_f32_i64", "0x1.19999ap+0", "1");
+  // equals("trunc_s_f32_i64", "1.5", "1");
+  // equals("trunc_s_f32_i64", "-1.0", "-1");
+  // equals("trunc_s_f32_i64", "-0x1.19999ap+0", "-1");
+  // equals("trunc_s_f32_i64", "-1.5", "-1");
+  // equals("trunc_s_f32_i64", "-1.9", "-1");
+  // equals("trunc_s_f32_i64", "-2.0", "-2");
+  // equals("trunc_s_f32_i64", "4294967296", "4294967296"); ;; 0x1.00000p+32 -> 1 0000 0000
+  // equals("trunc_s_f32_i64", "-4294967296", "-4294967296"); ;; -0x1.00000p+32 -> ffff ffff 0000 0000
+  // equals("trunc_s_f32_i64", "9223371487098961920.0", "9223371487098961920");
+  // equals("trunc_s_f32_i64", "-9223372036854775808.0", "-9223372036854775808");
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const 9223372036854775808.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const -9223373136366403584.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const nan:0x200000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_s_f32" (f32.const -nan:0x200000)) "invalid conversion to integer")
+
+  // equals("trunc_u_f32_i64", "0.0", "0");
+  // equals("trunc_u_f32_i64", "-0.0", "0");
+  // equals("trunc_u_f32_i64", "0x1p-149", "0");
+  // equals("trunc_u_f32_i64", "-0x1p-149", "0");
+  // equals("trunc_u_f32_i64", "1.0", "1");
+  // equals("trunc_u_f32_i64", "0x1.19999ap+0", "1");
+  // equals("trunc_u_f32_i64", "1.5", "1");
+  // equals("trunc_u_f32_i64", "4294967296", "4294967296");
+  // equals("trunc_u_f32_i64", "18446742974197923840.0", "-1099511627776");
+  // equals("trunc_u_f32_i64", "-0x1.ccccccp-1", "0");
+  // equals("trunc_u_f32_i64", "-0x1.fffffep-1", "0");
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const 18446744073709551616.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const -1.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const nan:0x200000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_u_f32" (f32.const -nan:0x200000)) "invalid conversion to integer")
+
+  // equals("trunc_s_f64_i64", "0.0", "0");
+  // equals("trunc_s_f64_i64", "-0.0", "0");
+  // equals("trunc_s_f64_i64", "0x0.0000000000001p-1022", "0");
+  // equals("trunc_s_f64_i64", "-0x0.0000000000001p-1022", "0");
+  // equals("trunc_s_f64_i64", "1.0", "1");
+  // equals("trunc_s_f64_i64", "0x1.199999999999ap+0", "1");
+  // equals("trunc_s_f64_i64", "1.5", "1");
+  // equals("trunc_s_f64_i64", "-1.0", "-1");
+  // equals("trunc_s_f64_i64", "-0x1.199999999999ap+0", "-1");
+  // equals("trunc_s_f64_i64", "-1.5", "-1");
+  // equals("trunc_s_f64_i64", "-1.9", "-1");
+  // equals("trunc_s_f64_i64", "-2.0", "-2");
+  // equals("trunc_s_f64_i64", "4294967296", "4294967296"); ;; 0x1.00000p+32 -> 1 0000 0000
+  // equals("trunc_s_f64_i64", "-4294967296", "-4294967296"); ;; -0x1.00000p+32 -> ffff ffff 0000 0000
+  // equals("trunc_s_f64_i64", "9223372036854774784.0", "9223372036854774784");
+  // equals("trunc_s_f64_i64", "-9223372036854775808.0", "-9223372036854775808");
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const 9223372036854775808.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const -9223372036854777856.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const nan:0x4000000000000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_s_f64" (f64.const -nan:0x4000000000000)) "invalid conversion to integer")
+
+  // equals("trunc_u_f64_i64", "0.0", "0");
+  // equals("trunc_u_f64_i64", "-0.0", "0");
+  // equals("trunc_u_f64_i64", "0x0.0000000000001p-1022", "0");
+  // equals("trunc_u_f64_i64", "-0x0.0000000000001p-1022", "0");
+  // equals("trunc_u_f64_i64", "1.0", "1");
+  // equals("trunc_u_f64_i64", "0x1.199999999999ap+0", "1");
+  // equals("trunc_u_f64_i64", "1.5", "1");
+  // equals("trunc_u_f64_i64", "4294967295", "0xffffffff");
+  // equals("trunc_u_f64_i64", "4294967296", "0x100000000");
+  // equals("trunc_u_f64_i64", "18446744073709549568.0", "-2048");
+  // equals("trunc_u_f64_i64", "-0x1.ccccccccccccdp-1", "0");
+  // equals("trunc_u_f64_i64", "-0x1.fffffffffffffp-1", "0");
+  // equals("trunc_u_f64_i64", "1e8", "100000000");
+  // equals("trunc_u_f64_i64", "1e16", "10000000000000000");
+  // equals("trunc_u_f64_i64", "9223372036854775808", "-9223372036854775808");
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const 18446744073709551616.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const -1.0)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const -inf)) "integer overflow")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const nan:0x4000000000000)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const -nan)) "invalid conversion to integer")
+  // (assert_trap (invoke "i64.trunc_u_f64" (f64.const -nan:0x4000000000000)) "invalid conversion to integer")
+
+  // equals("convert_s_i32_f32", "1", "1.0");
+  // equals("convert_s_i32_f32", "-1", "-1.0");
+  // equals("convert_s_i32_f32", "0", "0.0");
+  // equals("convert_s_i32_f32", "2147483647", "2147483648");
+  // equals("convert_s_i32_f32", "-2147483648", "-2147483648");
+  // equals("convert_s_i32_f32", "1234567890", "0x1.26580cp+30");
+  // ;; Test rounding directions.
+  // equals("convert_s_i32_f32", "16777217", "16777216.0");
+  // equals("convert_s_i32_f32", "-16777217", "-16777216.0");
+  // equals("convert_s_i32_f32", "16777219", "16777220.0");
+  // equals("convert_s_i32_f32", "-16777219", "-16777220.0");
+
+  // equals("convert_s_i64_f32", "1", "1.0");
+  // equals("convert_s_i64_f32", "-1", "-1.0");
+  // equals("convert_s_i64_f32", "0", "0.0");
+  // equals("convert_s_i64_f32", "9223372036854775807", "9223372036854775807");
+  // equals("convert_s_i64_f32", "-9223372036854775808", "-9223372036854775808");
+  // equals("convert_s_i64_f32", "314159265358979", "0x1.1db9e8p+48"); ;; PI
+  // ;; Test rounding directions.
+  // equals("convert_s_i64_f32", "16777217", "16777216.0");
+  // equals("convert_s_i64_f32", "-16777217", "-16777216.0");
+  // equals("convert_s_i64_f32", "16777219", "16777220.0");
+  // equals("convert_s_i64_f32", "-16777219", "-16777220.0");
+
+  // equals("convert_s_i32_f64", "1", "1.0");
+  // equals("convert_s_i32_f64", "-1", "-1.0");
+  // equals("convert_s_i32_f64", "0", "0.0");
+  // equals("convert_s_i32_f64", "2147483647", "2147483647");
+  // equals("convert_s_i32_f64", "-2147483648", "-2147483648");
+  // equals("convert_s_i32_f64", "987654321", "987654321");
+
+  // equals("convert_s_i64_f64", "1", "1.0");
+  // equals("convert_s_i64_f64", "-1", "-1.0");
+  // equals("convert_s_i64_f64", "0", "0.0");
+  // equals("convert_s_i64_f64", "9223372036854775807", "9223372036854775807");
+  // equals("convert_s_i64_f64", "-9223372036854775808", "-9223372036854775808");
+  // equals("convert_s_i64_f64", "4669201609102990", "4669201609102990"); ;; Feigenbaum
+  // ;; Test rounding directions.
+  // equals("convert_s_i64_f64", "9007199254740993", "9007199254740992");
+  // equals("convert_s_i64_f64", "-9007199254740993", "-9007199254740992");
+  // equals("convert_s_i64_f64", "9007199254740995", "9007199254740996");
+  // equals("convert_s_i64_f64", "-9007199254740995", "-9007199254740996");
+
+  // equals("convert_u_i32_f32", "1", "1.0");
+  // equals("convert_u_i32_f32", "0", "0.0");
+  // equals("convert_u_i32_f32", "2147483647", "2147483648");
+  // equals("convert_u_i32_f32", "-2147483648", "2147483648");
+  // equals("convert_u_i32_f32", "0x12345678", "0x1.234568p+28");
+  // equals("convert_u_i32_f32", "0xffffffff", "4294967296.0");
+  // equals("convert_u_i32_f32", "0x80000080", "0x1.000000p+31");
+  // equals("convert_u_i32_f32", "0x80000081", "0x1.000002p+31");
+  // equals("convert_u_i32_f32", "0x80000082", "0x1.000002p+31");
+  // equals("convert_u_i32_f32", "0xfffffe80", "0x1.fffffcp+31");
+  // equals("convert_u_i32_f32", "0xfffffe81", "0x1.fffffep+31");
+  // equals("convert_u_i32_f32", "0xfffffe82", "0x1.fffffep+31");
+  // ;; Test rounding directions.
+  // equals("convert_u_i32_f32", "16777217", "16777216.0");
+  // equals("convert_u_i32_f32", "16777219", "16777220.0");
+
+  // equals("convert_u_i64_f32", "1", "1.0");
+  // equals("convert_u_i64_f32", "0", "0.0");
+  // equals("convert_u_i64_f32", "9223372036854775807", "9223372036854775807");
+  // equals("convert_u_i64_f32", "-9223372036854775808", "9223372036854775808");
+  // equals("convert_u_i64_f32", "0xffffffffffffffff", "18446744073709551616.0");
+  // ;; Test rounding directions.
+  // equals("convert_u_i64_f32", "16777217", "16777216.0");
+  // equals("convert_u_i64_f32", "16777219", "16777220.0");
+
+  // equals("convert_u_i32_f64", "1", "1.0");
+  // equals("convert_u_i32_f64", "0", "0.0");
+  // equals("convert_u_i32_f64", "2147483647", "2147483647");
+  // equals("convert_u_i32_f64", "-2147483648", "2147483648");
+  // equals("convert_u_i32_f64", "0xffffffff", "4294967295.0");
+
+  // equals("convert_u_i64_f64", "1", "1.0");
+  // equals("convert_u_i64_f64", "0", "0.0");
+  // equals("convert_u_i64_f64", "9223372036854775807", "9223372036854775807");
+  // equals("convert_u_i64_f64", "-9223372036854775808", "9223372036854775808");
+  // equals("convert_u_i64_f64", "0xffffffffffffffff", "18446744073709551616.0");
+  // equals("convert_u_i64_f64", "0x8000000000000400", "0x1.0000000000000p+63");
+  // equals("convert_u_i64_f64", "0x8000000000000401", "0x1.0000000000001p+63");
+  // equals("convert_u_i64_f64", "0x8000000000000402", "0x1.0000000000001p+63");
+  // equals("convert_u_i64_f64", "0xfffffffffffff400", "0x1.ffffffffffffep+63");
+  // equals("convert_u_i64_f64", "0xfffffffffffff401", "0x1.fffffffffffffp+63");
+  // equals("convert_u_i64_f64", "0xfffffffffffff402", "0x1.fffffffffffffp+63");
+  // ;; Test rounding directions.
+  // equals("convert_u_i64_f64", "9007199254740993", "9007199254740992");
+  // equals("convert_u_i64_f64", "9007199254740995", "9007199254740996");
+
+  // equals("promote_f32_f64", "0.0", "0.0");
+  // equals("promote_f32_f64", "-0.0", "-0.0");
+  // equals("promote_f32_f64", "0x1p-149", "0x1p-149");
+  // equals("promote_f32_f64", "-0x1p-149", "-0x1p-149");
+  // equals("promote_f32_f64", "1.0", "1.0");
+  // equals("promote_f32_f64", "-1.0", "-1.0");
+  // equals("promote_f32_f64", "-0x1.fffffep+127", "-0x1.fffffep+127");
+  // equals("promote_f32_f64", "0x1.fffffep+127", "0x1.fffffep+127");
+  // ;; Generated randomly by picking a random int and reinterpret it to float.
+  // equals("promote_f32_f64", "0x1p-119", "0x1p-119");
+  // ;; Generated randomly by picking a random float.
+  // equals("promote_f32_f64", "0x1.8f867ep+125", "6.6382536710104395e+37");
+  // equals("promote_f32_f64", "inf", "inf");
+  // equals("promote_f32_f64", "-inf", "-inf");
+  // (assert_return_canonical_nan (invoke "f64.promote_f32" (f32.const nan)))
+  // (assert_return_arithmetic_nan (invoke "f64.promote_f32" (f32.const nan:0x200000)))
+  // (assert_return_canonical_nan (invoke "f64.promote_f32" (f32.const -nan)))
+  // (assert_return_arithmetic_nan (invoke "f64.promote_f32" (f32.const -nan:0x200000)))
+
+  // equals("demote_f64_f32", "0.0", "0.0");
+  // equals("demote_f64_f32", "-0.0", "-0.0");
+  // equals("demote_f64_f32", "0x0.0000000000001p-1022", "0.0");
+  // equals("demote_f64_f32", "-0x0.0000000000001p-1022", "-0.0");
+  // equals("demote_f64_f32", "1.0", "1.0");
+  // equals("demote_f64_f32", "-1.0", "-1.0");
+  // equals("demote_f64_f32", "0x1.fffffe0000000p-127", "0x1p-126");
+  // equals("demote_f64_f32", "-0x1.fffffe0000000p-127", "-0x1p-126");
+  // equals("demote_f64_f32", "0x1.fffffdfffffffp-127", "0x1.fffffcp-127");
+  // equals("demote_f64_f32", "-0x1.fffffdfffffffp-127", "-0x1.fffffcp-127");
+  // equals("demote_f64_f32", "0x1p-149", "0x1p-149");
+  // equals("demote_f64_f32", "-0x1p-149", "-0x1p-149");
+  // equals("demote_f64_f32", "0x1.fffffd0000000p+127", "0x1.fffffcp+127");
+  // equals("demote_f64_f32", "-0x1.fffffd0000000p+127", "-0x1.fffffcp+127");
+  // equals("demote_f64_f32", "0x1.fffffd0000001p+127", "0x1.fffffep+127");
+  // equals("demote_f64_f32", "-0x1.fffffd0000001p+127", "-0x1.fffffep+127");
+  // equals("demote_f64_f32", "0x1.fffffep+127", "0x1.fffffep+127");
+  // equals("demote_f64_f32", "-0x1.fffffep+127", "-0x1.fffffep+127");
+  // equals("demote_f64_f32", "0x1.fffffefffffffp+127", "0x1.fffffep+127");
+  // equals("demote_f64_f32", "-0x1.fffffefffffffp+127", "-0x1.fffffep+127");
+  // equals("demote_f64_f32", "0x1.ffffffp+127", "inf");
+  // equals("demote_f64_f32", "-0x1.ffffffp+127", "-inf");
+  // equals("demote_f64_f32", "0x1p-119", "0x1p-119");
+  // equals("demote_f64_f32", "0x1.8f867ep+125", "0x1.8f867ep+125");
+  // equals("demote_f64_f32", "inf", "inf");
+  // equals("demote_f64_f32", "-inf", "-inf");
+  // equals("demote_f64_f32", "0x1.0000000000001p+0", "1.0");
+  // equals("demote_f64_f32", "0x1.fffffffffffffp-1", "1.0");
+  // equals("demote_f64_f32", "0x1.0000010000000p+0", "0x1.000000p+0");
+  // equals("demote_f64_f32", "0x1.0000010000001p+0", "0x1.000002p+0");
+  // equals("demote_f64_f32", "0x1.000002fffffffp+0", "0x1.000002p+0");
+  // equals("demote_f64_f32", "0x1.0000030000000p+0", "0x1.000004p+0");
+  // equals("demote_f64_f32", "0x1.0000050000000p+0", "0x1.000004p+0");
+  // equals("demote_f64_f32", "0x1.0000010000000p+24", "0x1.0p+24");
+  // equals("demote_f64_f32", "0x1.0000010000001p+24", "0x1.000002p+24");
+  // equals("demote_f64_f32", "0x1.000002fffffffp+24", "0x1.000002p+24");
+  // equals("demote_f64_f32", "0x1.0000030000000p+24", "0x1.000004p+24");
+  // equals("demote_f64_f32", "0x1.4eae4f7024c7p+108", "0x1.4eae5p+108");
+  // equals("demote_f64_f32", "0x1.a12e71e358685p-113", "0x1.a12e72p-113");
+  // equals("demote_f64_f32", "0x1.cb98354d521ffp-127", "0x1.cb9834p-127");
+  // equals("demote_f64_f32", "-0x1.6972b30cfb562p+1", "-0x1.6972b4p+1");
+  // equals("demote_f64_f32", "-0x1.bedbe4819d4c4p+112", "-0x1.bedbe4p+112");
+  // (assert_return_canonical_nan (invoke "f32.demote_f64" (f64.const nan)))
+  // (assert_return_arithmetic_nan (invoke "f32.demote_f64" (f64.const nan:0x4000000000000)))
+  // (assert_return_canonical_nan (invoke "f32.demote_f64" (f64.const -nan)))
+  // (assert_return_arithmetic_nan (invoke "f32.demote_f64" (f64.const -nan:0x4000000000000)))
+  // equals("demote_f64_f32", "0x1p-1022", "0.0");
+  // equals("demote_f64_f32", "-0x1p-1022", "-0.0");
+  // equals("demote_f64_f32", "0x1.0p-150", "0.0");
+  // equals("demote_f64_f32", "-0x1.0p-150", "-0.0");
+  // equals("demote_f64_f32", "0x1.0000000000001p-150", "0x1p-149");
+  // equals("demote_f64_f32", "-0x1.0000000000001p-150", "-0x1p-149");
+
+  // equals("reinterpret_i32_f32", "0", "0.0");
+  // equals("reinterpret_i32_f32", "0x80000000", "-0.0");
+  // equals("reinterpret_i32_f32", "1", "0x1p-149");
+  // equals("reinterpret_i32_f32", "-1", "-nan:0x7fffff");
+  // equals("reinterpret_i32_f32", "123456789", "0x1.b79a2ap-113");
+  // equals("reinterpret_i32_f32", "-2147483647", "-0x1p-149");
+  // equals("reinterpret_i32_f32", "0x7f800000", "inf");
+  // equals("reinterpret_i32_f32", "0xff800000", "-inf");
+  // equals("reinterpret_i32_f32", "0x7fc00000", "nan");
+  // equals("reinterpret_i32_f32", "0xffc00000", "-nan");
+  // equals("reinterpret_i32_f32", "0x7fa00000", "nan:0x200000");
+  // equals("reinterpret_i32_f32", "0xffa00000", "-nan:0x200000");
+
+  // equals("reinterpret_i64_f64", "0", "0.0");
+  // equals("reinterpret_i64_f64", "1", "0x0.0000000000001p-1022");
+  // equals("reinterpret_i64_f64", "-1", "-nan:0xfffffffffffff");
+  // equals("reinterpret_i64_f64", "0x8000000000000000", "-0.0");
+  // equals("reinterpret_i64_f64", "1234567890", "0x0.00000499602d2p-1022");
+  // equals("reinterpret_i64_f64", "-9223372036854775807", "-0x0.0000000000001p-1022");
+  // equals("reinterpret_i64_f64", "0x7ff0000000000000", "inf");
+  // equals("reinterpret_i64_f64", "0xfff0000000000000", "-inf");
+  // equals("reinterpret_i64_f64", "0x7ff8000000000000", "nan");
+  // equals("reinterpret_i64_f64", "0xfff8000000000000", "-nan");
+  // equals("reinterpret_i64_f64", "0x7ff4000000000000", "nan:0x4000000000000");
+  // equals("reinterpret_i64_f64", "0xfff4000000000000", "-nan:0x4000000000000");
+
+  equals("reinterpret_f32_i32", "0.0", "0");
+  equals("reinterpret_f32_i32", "-0.0", "0x80000000");
+  equals("reinterpret_f32_i32", "0x1p-149", "1");
+  // equals("reinterpret_f32_i32", "-nan:0x7fffff", "-1");
+  equals("reinterpret_f32_i32", "-0x1p-149", "0x80000001");
+  equals("reinterpret_f32_i32", "1.0", "1065353216");
+  equals("reinterpret_f32_i32", "3.1415926", "1078530010");
+  equals("reinterpret_f32_i32", "0x1.fffffep+127", "2139095039");
+  equals("reinterpret_f32_i32", "-0x1.fffffep+127", "-8388609");
+  // equals("reinterpret_f32_i32", "inf", "0x7f800000");
+  // equals("reinterpret_f32_i32", "-inf", "0xff800000");
+  // equals("reinterpret_f32_i32", "nan", "0x7fc00000");
+  // equals("reinterpret_f32_i32", "-nan", "0xffc00000");
+  // equals("reinterpret_f32_i32", "nan:0x200000", "0x7fa00000");
+  // equals("reinterpret_f32_i32", "-nan:0x200000", "0xffa00000");
+
+  // equals("reinterpret_f64_i64", "0.0", "0");
+  // equals("reinterpret_f64_i64", "-0.0", "0x8000000000000000");
+  // equals("reinterpret_f64_i64", "0x0.0000000000001p-1022", "1");
+  // equals("reinterpret_f64_i64", "-nan:0xfffffffffffff", "-1");
+  // equals("reinterpret_f64_i64", "-0x0.0000000000001p-1022", "0x8000000000000001");
+  // equals("reinterpret_f64_i64", "1.0", "4607182418800017408");
+  // equals("reinterpret_f64_i64", "3.14159265358979", "4614256656552045841");
+  // equals("reinterpret_f64_i64", "0x1.fffffffffffffp+1023", "9218868437227405311");
+  // equals("reinterpret_f64_i64", "-0x1.fffffffffffffp+1023", "-4503599627370497");
+  // equals("reinterpret_f64_i64", "inf", "0x7ff0000000000000");
+  // equals("reinterpret_f64_i64", "-inf", "0xfff0000000000000");
+  // equals("reinterpret_f64_i64", "nan", "0x7ff8000000000000");
+  // equals("reinterpret_f64_i64", "-nan", "0xfff8000000000000");
+  // equals("reinterpret_f64_i64", "nan:0x4000000000000", "0x7ff4000000000000");
+  // equals("reinterpret_f64_i64", "-nan:0x4000000000000", "0xfff4000000000000");
+});

--- a/test/interpreter/fixtures/conversions/module.wast
+++ b/test/interpreter/fixtures/conversions/module.wast
@@ -1,0 +1,7 @@
+(module
+  (func $reinterpret_f32_i32 (param f32) (result i32)
+   (get_local 0)
+   (i32.reinterpret/f32)
+  )
+  (export "reinterpret_f32_i32" (func $reinterpret_f32_i32))
+)

--- a/test/interpreter/index.js
+++ b/test/interpreter/index.js
@@ -26,6 +26,7 @@ describe("interpreter", () => {
         const sandbox = {
           WebAssembly,
           watfmodule: module,
+          require: require,
           console: global.console,
           assert: chai.assert,
           it,

--- a/test/interpreter/kernel/exec/conversion-instructions.js
+++ b/test/interpreter/kernel/exec/conversion-instructions.js
@@ -1,0 +1,131 @@
+// @flow
+const Long = require("long");
+const { assert } = require("chai");
+
+const { i32 } = require("../../../../lib/interpreter/runtime/values/i32");
+const { i64 } = require("../../../../lib/interpreter/runtime/values/i64");
+const { f32 } = require("../../../../lib/interpreter/runtime/values/f32");
+const { f64 } = require("../../../../lib/interpreter/runtime/values/f64");
+const {
+  castIntoStackLocalOfType
+} = require("../../../../lib/interpreter/runtime/castIntoStackLocalOfType");
+const t = require("../../../../lib/compiler/AST");
+const {
+  executeStackFrame
+} = require("../../../../lib/interpreter/kernel/exec");
+const {
+  createStackFrame
+} = require("../../../../lib/interpreter/kernel/stackframe");
+
+describe("kernel exec - conversion instructions", () => {
+  const operations = [
+    {
+      name: "i32.reinterpret/f32 - typical case",
+
+      args: [{ value: 3.1415926, type: "f32" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f32", "i32")
+      ],
+
+      resEqual: new i32(1078530010)
+    },
+
+    {
+      name: "i32.reinterpret/f32 - boundary value",
+
+      args: [{ value: 0.0, type: "f32" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f32", "i32")
+      ],
+
+      resEqual: new i32(0)
+    },
+
+    {
+      name: "i32.reinterpret/f32 - boundary value",
+
+      args: [{ value: -0.0, type: "f32" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f32", "i32")
+      ],
+
+      resEqual: new i32(0x80000000)
+    },
+
+    {
+      name: "i64.reinterpret/f64 - boundary value",
+
+      args: [{ value: 0.0, type: "f64" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("0"))
+    },
+
+    {
+      name: "i64.reinterpret/f64 - typical case",
+
+      args: [{ value: 3.14159265358979, type: "f64" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("4614256656552045841"))
+    },
+
+    {
+      name: "i64.reinterpret/f64 - boundary value",
+
+      args: [{ value: 0.0, type: "f64" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("0"))
+    },
+
+    {
+      name: "i64.reinterpret/f64 - boundary value",
+
+      args: [{ value: -0.0, type: "f64" }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("8000000000000000", false, 16))
+    }
+  ];
+
+  operations.forEach(op => {
+    describe(op.name, () => {
+      it("should get the correct result", () => {
+        const args = op.args.map(({ value, type }) =>
+          castIntoStackLocalOfType(type, value)
+        );
+
+        const stackFrame = createStackFrame(op.code, args);
+        const res = executeStackFrame(stackFrame);
+
+        assert.isTrue(
+          res.value.equals(op.resEqual),
+          `expected ${res.value.toString()} to equal ${op.resEqual.toString()}`
+        );
+      });
+    });
+  });
+});

--- a/test/interpreter/kernel/exec/conversion-instructions.js
+++ b/test/interpreter/kernel/exec/conversion-instructions.js
@@ -4,8 +4,6 @@ const { assert } = require("chai");
 
 const { i32 } = require("../../../../lib/interpreter/runtime/values/i32");
 const { i64 } = require("../../../../lib/interpreter/runtime/values/i64");
-const { f32 } = require("../../../../lib/interpreter/runtime/values/f32");
-const { f64 } = require("../../../../lib/interpreter/runtime/values/f64");
 const {
   castIntoStackLocalOfType
 } = require("../../../../lib/interpreter/runtime/castIntoStackLocalOfType");


### PR DESCRIPTION
I've made some progress towards #63 - this PR implements `i32.reinterpret/f32`, again using a transformed version of the WebAssembly spec tests.

The most notable change here is that I've split the `NumberInterface` interface into three separate interfaces, reflecting the different operations that are available on floats vs. integers.

**UPDATE**

I've completed `i32.reinterpret/f32` and `i64.reinterpret/f64` - with the f64 / i64 functionality tested via unit tests rather than the spec level tests