### PR TITLE
Implemented i32.store and i64.store

### DIFF
--- a/src/compiler/parsing/watf/grammar.js
+++ b/src/compiler/parsing/watf/grammar.js
@@ -1,4 +1,5 @@
 // @flow
+import { parse32I } from "./number-literals";
 
 const { tokens, keywords } = require("./tokenizer");
 const t = require("../../AST");
@@ -159,11 +160,11 @@ export function parse(tokensList: Array<Object>, source: string): Program {
         );
       }
 
-      const limits = t.limits(token.value);
+      const limits = t.limits(parse32I(token.value));
       eatToken();
 
       if (token.type === tokens.number) {
-        limits.max = token.value;
+        limits.max = parse32I(token.value);
         eatToken();
       }
 

--- a/src/interpreter/index.js
+++ b/src/interpreter/index.js
@@ -10,12 +10,9 @@ const { createStackFrame } = require("./kernel/stackframe");
 const { isTrapped } = require("./kernel/signals");
 const { RuntimeError } = require("../errors");
 const { Module } = require("../compiler/compile/module");
-const { Memory } = require("./runtime/values/memory");
 const { Table } = require("./runtime/values/table");
 const { createAllocator } = require("./kernel/memory");
 const importObjectUtils = require("./import-object");
-
-const ALLOCATOR_MEMORY = new Memory({ initial: 1, maximum: 1024 });
 
 export class Instance {
   exports: any;
@@ -44,7 +41,7 @@ export class Instance {
     /**
      * Create Module's default memory allocator
      */
-    this._allocator = createAllocator(ALLOCATOR_MEMORY);
+    this._allocator = createAllocator();
 
     /**
      * importObject.

--- a/src/interpreter/kernel/memory.js
+++ b/src/interpreter/kernel/memory.js
@@ -1,43 +1,37 @@
 // @flow
-
 export const NULL = 0x0;
 
-// It's an index not an actual pointer
-// FIXME(sven): remove this ^
-export const ptrsize = 1;
-
-export function createAllocator(memory: MemoryInstance): Allocator {
-  const heap = memory.buffer;
-
-  if (heap === null) {
-    throw new Error("heap is not initalized");
-  }
+// Allocates memory addresses within the store
+// https://webassembly.github.io/spec/core/exec/modules.html#alloc
+export function createAllocator(): Allocator {
+  // https://webassembly.github.io/spec/core/exec/runtime.html#store
+  const store = [];
+  let offset = 0;
 
   function malloc(size: Bytes): Addr {
-    memory.offset += size;
+    offset += size;
 
     return {
-      index: memory.offset,
+      index: offset,
       size
     };
   }
 
   function get(p: Addr): any {
-    return heap[p.index];
+    return store[p.index];
   }
 
   function set(p: Addr, value: any) {
-    heap[p.index] = value;
+    store[p.index] = value;
   }
 
   function free(p: Addr) {
-    heap[p.index] = NULL;
+    store[p.index] = NULL;
   }
 
   return {
     malloc,
     free,
-
     get,
     set
   };

--- a/src/interpreter/runtime/values/i32.js
+++ b/src/interpreter/runtime/values/i32.js
@@ -274,6 +274,18 @@ export class i32 implements IntegerValue<i32> {
     // https://webassembly.github.io/spec/core/exec/numerics.html#boolean-interpretation
     return this._value == 1;
   }
+
+  toByteArray(): Array<number> {
+    const byteArray: Array<number> = new Array(4);
+    for (
+      let offset = 0, shift = 0;
+      offset < byteArray.length;
+      offset++, shift += 8
+    ) {
+      byteArray[offset] = (this._value >>> shift) & 0xff;
+    }
+    return byteArray;
+  }
 }
 
 export function createValueFromAST(value: number): StackLocal {

--- a/src/interpreter/runtime/values/i64.js
+++ b/src/interpreter/runtime/values/i64.js
@@ -172,6 +172,21 @@ export class i64 implements IntegerValue<i64> {
     // https://webassembly.github.io/spec/core/exec/numerics.html#boolean-interpretation
     return this.toNumber() == 1;
   }
+
+  toByteArray(): Array<number> {
+    const byteArray: Array<number> = new Array(8);
+    for (
+      let offset = 0, shift = 0;
+      offset < byteArray.length;
+      offset++, shift += 8
+    ) {
+      byteArray[offset] = this._value
+        .shru(shift)
+        .and(0xff)
+        .toNumber();
+    }
+    return byteArray;
+  }
 }
 
 export function createValueFromAST(value: LongNumber): StackLocal {

--- a/src/interpreter/runtime/values/memory.js
+++ b/src/interpreter/runtime/values/memory.js
@@ -1,13 +1,12 @@
 // @flow
 
-const WEBASSEMBLY_PAGE_SIZE = 2 ** 16 /* bytes */;
+const WEBASSEMBLY_PAGE_SIZE = 64 * 1024 /* 64KiB */;
 
-export class Memory {
+export class Memory implements MemoryInstance {
   _initialBytes: number;
   _maximumBytes: number;
 
-  offset: number;
-  buffer: Array<any>;
+  buffer: ArrayBuffer;
 
   constructor(descr: MemoryDescriptor) {
     if (typeof descr !== "object") {
@@ -32,7 +31,6 @@ export class Memory {
   }
 
   _allocateInitial() {
-    this.buffer = Array(this._initialBytes);
-    this.offset = 0;
+    this.buffer = new ArrayBuffer(this._initialBytes);
   }
 }

--- a/src/interpreter/runtime/values/module.js
+++ b/src/interpreter/runtime/values/module.js
@@ -1,10 +1,14 @@
 // @flow
+import { Memory } from "./memory";
+import { debuglog } from "util";
 
 const importObjectUtils = require("../../import-object");
 const { traverse } = require("../../../compiler/AST/traverse");
 const func = require("./func");
 const global = require("./global");
 const { LinkError, CompileError } = require("../../../errors");
+
+const DEFAULT_LINEAR_MEMORY = new Memory({ initial: 1, maximum: 1024 });
 
 export function createInstance(
   allocator: Allocator,
@@ -92,8 +96,7 @@ export function createInstance(
     },
 
     Memory({ node }: NodePath<Memory>) {
-      // TODO(sven): implement exporting a Memory instance
-      const memoryinstance = null;
+      const memoryinstance = DEFAULT_LINEAR_MEMORY;
 
       const addr = allocator.malloc(1 /* size of the memoryinstance struct */);
       allocator.set(addr, memoryinstance);

--- a/src/interpreter/runtime/values/module.js
+++ b/src/interpreter/runtime/values/module.js
@@ -92,10 +92,7 @@ export function createInstance(
     },
 
     Memory({ node }: NodePath<Memory>) {
-      const limits = {
-        min: Number(node.limits.min),
-        max: node.limits.max ? Number(node.limits.max) : undefined
-      };
+      const limits = node.limits;
 
       if (limits.max && limits.max < limits.min) {
         throw new RuntimeError("size minimum must not be greater than maximum");

--- a/src/interpreter/runtime/values/number.js
+++ b/src/interpreter/runtime/values/number.js
@@ -93,4 +93,8 @@ export class Float<U> implements FloatingPointValue<Float<U>, U> {
   toString(): string {
     return this._value.toString();
   }
+
+  toByteArray(): Array<number> {
+    throw new RuntimeError("unsupported operation");
+  }
 }

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -122,6 +122,7 @@ interface NumericOperations<T> {
   toString(): string;
   isTrue(): boolean;
   toString(): string;
+  toByteArray(): Array<number>;
 }
 
 type Label = {
@@ -131,11 +132,6 @@ type Label = {
 };
 
 type Signal = number;
-
-interface MemoryInstance {
-  buffer: Array<any>;
-  offset: number;
-}
 
 interface Allocator {
   malloc(Bytes): Addr;

--- a/src/types/userland.js
+++ b/src/types/userland.js
@@ -25,6 +25,10 @@ type MemoryDescriptor = {
   maximum?: number
 };
 
+interface MemoryInstance {
+  buffer: ArrayBuffer;
+}
+
 type TableDescriptor = {
   element: string,
   initial: number,

--- a/test/compiler/parsing/fixtures/watf/export/memory/expected.json
+++ b/test/compiler/parsing/fixtures/watf/export/memory/expected.json
@@ -9,7 +9,7 @@
           "type": "Memory",
           "limits": {
             "type": "Limit",
-            "min": "0"
+            "min": 0
           },
           "id": {
             "type": "Identifier",

--- a/test/compiler/parsing/fixtures/watf/memory/basic/actual.wast
+++ b/test/compiler/parsing/fixtures/watf/memory/basic/actual.wast
@@ -3,3 +3,4 @@
 (memory "test" 1 2)
 (memory "test" 1)
 (memory $a 0)
+(memory 0xfe)

--- a/test/compiler/parsing/fixtures/watf/memory/basic/expected.json
+++ b/test/compiler/parsing/fixtures/watf/memory/basic/expected.json
@@ -5,7 +5,7 @@
       "type": "Memory",
       "limits": {
         "type": "Limit",
-        "min": "1"
+        "min": 1
       },
       "id": {
         "type": "Identifier",
@@ -16,8 +16,8 @@
       "type": "Memory",
       "limits": {
         "type": "Limit",
-        "min": "1",
-        "max": "2"
+        "min": 1,
+        "max": 2
       },
       "id": {
         "type": "Identifier",
@@ -28,8 +28,8 @@
       "type": "Memory",
       "limits": {
         "type": "Limit",
-        "min": "1",
-        "max": "2"
+        "min": 1,
+        "max": 2
       },
       "id": {
         "type": "Identifier",
@@ -40,7 +40,7 @@
       "type": "Memory",
       "limits": {
         "type": "Limit",
-        "min": "1"
+        "min": 1
       },
       "id": {
         "type": "Identifier",
@@ -51,11 +51,22 @@
       "type": "Memory",
       "limits": {
         "type": "Limit",
-        "min": "0"
+        "min": 0
       },
       "id": {
         "type": "Identifier",
         "value": "a"
+      }
+    },
+    {
+      "type": "Memory",
+      "limits": {
+        "type": "Limit",
+        "min": 254
+      },
+      "id": {
+        "type": "Identifier",
+        "value": "memory_6"
       }
     }
   ]

--- a/test/compiler/parsing/fixtures/watf/memory/with-shorthand-export/expected.json
+++ b/test/compiler/parsing/fixtures/watf/memory/with-shorthand-export/expected.json
@@ -9,7 +9,7 @@
           "type": "Memory",
           "limits": {
             "type": "Limit",
-            "min": "0"
+            "min": 0
           },
           "id": {
             "type": "Identifier",

--- a/test/interpreter/fixtures/call-exported-func-with-mismatching-arity/exec.tjs
+++ b/test/interpreter/fixtures/call-exported-func-with-mismatching-arity/exec.tjs
@@ -3,5 +3,5 @@ const m = WebAssembly.instantiateFromSource(watfmodule);
 const fn = () => m.exports.add(1, 1, 9, 10);
 
 it("should throw an error for invalid arity", () => {
-  assert.throws(fn, "Function 2 called with 4 arguments but 2 expected");
+  assert.throws(fn, "Function 1 called with 4 arguments but 2 expected");
 });

--- a/test/interpreter/fixtures/export-memory-by-index/exec.tjs
+++ b/test/interpreter/fixtures/export-memory-by-index/exec.tjs
@@ -1,0 +1,5 @@
+it("should export the memory instance by index", () => {
+  const m = WebAssembly.instantiateFromSource(watfmodule);
+
+  assert.containsAllKeys(m.exports.memory, ["buffer"]);
+});

--- a/test/interpreter/fixtures/export-memory-by-index/module.wast
+++ b/test/interpreter/fixtures/export-memory-by-index/module.wast
@@ -1,0 +1,4 @@
+(module
+  (memory 0 1)
+  (export "memory" (memory 0))
+)

--- a/test/interpreter/fixtures/store-instruction/exec.tjs
+++ b/test/interpreter/fixtures/store-instruction/exec.tjs
@@ -1,0 +1,11 @@
+it("should export the memory instance by index", () => {
+  const m = WebAssembly.instantiateFromSource(watfmodule);
+
+  m.exports.store(0, 45);
+  m.exports.store(3 * 4, 77);
+
+  const i32Array = new Uint32Array(m.exports.memory.buffer);
+
+  assert.equal(i32Array[0], 45);
+  assert.equal(i32Array[3], 77);
+});

--- a/test/interpreter/fixtures/store-instruction/module.wast
+++ b/test/interpreter/fixtures/store-instruction/module.wast
@@ -1,0 +1,10 @@
+(module
+  (memory 25)
+  (func $store (param i32) (param i32)
+   (get_local 0)
+   (get_local 1)
+   (i32.store)
+  )
+  (export "store" (func $store))
+  (export "memory" (memory 0))
+)

--- a/test/interpreter/fixtures/store/exec.tjs
+++ b/test/interpreter/fixtures/store/exec.tjs
@@ -1,0 +1,15 @@
+it("should export the memory instance", () => {
+  const m = WebAssembly.instantiateFromSource(watfmodule);
+
+  assert.containsAllKeys(m.exports.memory, ["buffer"]);
+});
+
+it("should do stuff", () => {
+  const m = WebAssembly.instantiateFromSource(watfmodule);
+
+  m.exports.test();
+
+  const i32 = new Uint32Array(m.exports.memory.buffer);
+
+  assert.equal(i32[3], 1879048192);
+});

--- a/test/interpreter/fixtures/store/module.wast
+++ b/test/interpreter/fixtures/store/module.wast
@@ -1,0 +1,10 @@
+(module
+  (memory 1)
+  (func $test 
+    (i32.const 12)
+    (i32.const 0x70000000)
+    (i32.store)
+  )
+  (export "memory" (memory 0))
+  (export "test" (func $test))
+)

--- a/test/interpreter/kernel/exec/store-load-instructions.js
+++ b/test/interpreter/kernel/exec/store-load-instructions.js
@@ -1,0 +1,207 @@
+// @flow
+const { assert } = require("chai");
+
+const { Memory } = require("../../../../lib/interpreter/runtime/values/memory");
+const t = require("../../../../lib/compiler/AST");
+const {
+  executeStackFrame
+} = require("../../../../lib/interpreter/kernel/exec");
+const {
+  createStackFrame
+} = require("../../../../lib/interpreter/kernel/stackframe");
+
+describe("kernel exec - store / load instructions", () => {
+  let linearMemory;
+  let allocator;
+  let originatingModule;
+
+  const PAGE_SIZE = Math.pow(2, 16);
+  const PAGES = 2;
+  const I32_SIZE = 4;
+
+  beforeEach(() => {
+    linearMemory = new Memory({ initial: PAGES, maximum: 1024 });
+
+    originatingModule = {
+      memaddrs: [linearMemory]
+    };
+
+    allocator = {
+      get() {
+        return linearMemory;
+      }
+    };
+  });
+
+  it("should correctly store i32 values", () => {
+    const code = [
+      t.objectInstruction("const", "i32", [t.numberLiteral(12)]),
+      t.objectInstruction("const", "i32", [t.numberLiteral(0x70000000)]),
+      t.objectInstruction("store", "i32")
+    ];
+
+    const args = [];
+
+    const stackFrame = createStackFrame(
+      code,
+      args,
+      originatingModule,
+      allocator
+    );
+    executeStackFrame(stackFrame);
+
+    const i32Array = new Uint32Array(linearMemory.buffer);
+    assert.equal(i32Array[3], 1879048192);
+  });
+
+  it("should correctly store i64 values", () => {
+    const code = [
+      t.objectInstruction("const", "i32", [t.numberLiteral(8)]),
+      t.objectInstruction("const", "i64", [
+        t.numberLiteral("0x0102030405060708", "i64")
+      ]),
+      t.objectInstruction("store", "i64")
+    ];
+
+    const args = [];
+
+    const stackFrame = createStackFrame(
+      code,
+      args,
+      originatingModule,
+      allocator
+    );
+
+    executeStackFrame(stackFrame);
+
+    const i8Array = new Uint8Array(linearMemory.buffer);
+    assert.equal(i8Array[8], 8);
+    assert.equal(i8Array[9], 7);
+    assert.equal(i8Array[10], 6);
+    assert.equal(i8Array[11], 5);
+    assert.equal(i8Array[12], 4);
+    assert.equal(i8Array[13], 3);
+    assert.equal(i8Array[14], 2);
+    assert.equal(i8Array[15], 1);
+  });
+
+  it("should throw if no linear memory is defined", () => {
+    const code = [
+      t.objectInstruction("const", "i32", [t.numberLiteral(12)]),
+      t.objectInstruction("const", "i32", [t.numberLiteral(0x70000000)]),
+      t.objectInstruction("store", "i32")
+    ];
+
+    const args = [];
+
+    originatingModule.memaddrs = [];
+
+    const stackFrame = createStackFrame(
+      code,
+      args,
+      originatingModule,
+      allocator
+    );
+
+    assert.throws(() => executeStackFrame(stackFrame), "unknown memory");
+  });
+
+  it("should throw if memory accessed out of bounds", () => {
+    const code = [
+      t.objectInstruction("const", "i32", [
+        t.numberLiteral(PAGE_SIZE * PAGES - I32_SIZE + 1)
+      ]),
+      t.objectInstruction("const", "i32", [t.numberLiteral(0)]),
+      t.objectInstruction("store", "i32")
+    ];
+
+    const args = [];
+
+    const stackFrame = createStackFrame(
+      code,
+      args,
+      originatingModule,
+      allocator
+    );
+
+    assert.throws(
+      () => executeStackFrame(stackFrame),
+      "memory access out of bounds"
+    );
+  });
+
+  it("should not throw if memory accessed within bounds - upper boundary value", () => {
+    const code = [
+      t.objectInstruction("const", "i32", [
+        t.numberLiteral(PAGE_SIZE - I32_SIZE) // upper boundary value
+      ]),
+      t.objectInstruction("const", "i32", [t.numberLiteral(0)]),
+      t.objectInstruction("store", "i32")
+    ];
+
+    const args = [];
+
+    const stackFrame = createStackFrame(
+      code,
+      args,
+      originatingModule,
+      allocator
+    );
+
+    executeStackFrame(stackFrame);
+  });
+
+  it("should allow an offset to be specified", () => {
+    const code = [
+      t.objectInstruction("const", "i32", [t.numberLiteral(4)]),
+      t.objectInstruction("const", "i32", [t.numberLiteral(25)]),
+      t.objectInstruction("store", "i32", [], {
+        offset: 0x4
+      })
+    ];
+
+    const args = [];
+
+    const stackFrame = createStackFrame(
+      code,
+      args,
+      originatingModule,
+      allocator
+    );
+
+    executeStackFrame(stackFrame);
+
+    const i32Array = new Uint32Array(linearMemory.buffer);
+    assert.equal(i32Array[2], 25);
+  });
+
+  it("should ensure the offset is within the required bounds", () => {
+    const execueteStoreWithOffset = offset => {
+      const code = [
+        t.objectInstruction("const", "i32", [t.numberLiteral(0)]),
+        t.objectInstruction("const", "i32", [t.numberLiteral(25)]),
+        t.objectInstruction("store", "i32", [], {
+          offset
+        })
+      ];
+
+      const args = [];
+
+      const stackFrame = createStackFrame(
+        code,
+        args,
+        originatingModule,
+        allocator
+      );
+
+      executeStackFrame(stackFrame);
+    };
+
+    assert.doesNotThrow(() => execueteStoreWithOffset(0));
+    assert.throws(() => execueteStoreWithOffset(-1), "offset must be positive");
+    assert.throws(
+      () => execueteStoreWithOffset(0xffffffff + 1),
+      "offset must be less than or equal to 0xffffffff"
+    );
+  });
+});


### PR DESCRIPTION
A complete implementation of  i32.store and i64.store #59 

- The allocator no longer uses the runtime memory, it instead uses an array which represents the store (as per the spec)
- Memory now uses an `ArrayBuffer`
- 
- The `store` instruction accesses this via `frame.originatingModule.memaddrs[0]`, as defined in the spec: https://webassembly.github.io/spec/core/exec/instructions.html#exec-storen

You can see it fully working here:

https://github.com/xtuc/js-webassembly-interpreter/pull/123/files#diff-6d5a2351c718a8fe03cfcfa79ca3fd90
