### PR TITLE
Reinterpret inf in f32 and f64

### DIFF
--- a/src/compiler/AST/index.js
+++ b/src/compiler/AST/index.js
@@ -15,7 +15,7 @@ function assert(cond: boolean) {
   }
 }
 
-export function signature(object: string, name: string): Array {
+export function signature(object: string, name: string): SignatureMap {
   const signatures = {
     "reinterpret/f32": ["f32"]
   };
@@ -243,11 +243,13 @@ export function numberLiteral(
     value
   };
 
-  if (nan) {
+  if (nan === true) {
+    // $FlowIgnore
     x.nan = true;
   }
 
-  if (inf) {
+  if (inf === true) {
+    // $FlowIgnore
     x.inf = true;
   }
 

--- a/src/compiler/parsing/watf/grammar.js
+++ b/src/compiler/parsing/watf/grammar.js
@@ -716,7 +716,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
     /**
      * Parses the arguments of an instruction
      */
-    function parseFuncInstrArguments(signature: ?Array): AllArgs {
+    function parseFuncInstrArguments(signature: ?SignatureMap): AllArgs {
       const args: Array<Expression> = [];
       const namedArgs = {};
       let signaturePtr = 0;
@@ -895,7 +895,7 @@ export function parse(tokensList: Array<Object>, source: string): Program {
           }
         }
 
-        const signature = t.signature(object, name);
+        const signature = t.signature(object || "", name);
 
         const { args, namedArgs } = parseFuncInstrArguments(signature);
 

--- a/src/interpreter/runtime/castIntoStackLocalOfType.js
+++ b/src/interpreter/runtime/castIntoStackLocalOfType.js
@@ -19,12 +19,12 @@ export function castIntoStackLocalOfType(
     f64: f64.createValueFromAST
   };
 
-  if (nan) {
+  if (nan === true) {
     castFn.f32 = f32.createNanFromAST;
     castFn.f64 = f64.createNanFromAST;
   }
 
-  if (inf) {
+  if (inf === true) {
     castFn.f32 = f32.createInfFromAST;
     castFn.f64 = f64.createInfFromAST;
   }

--- a/src/interpreter/runtime/castIntoStackLocalOfType.js
+++ b/src/interpreter/runtime/castIntoStackLocalOfType.js
@@ -15,8 +15,10 @@ export function castIntoStackLocalOfType(
   const castFn = {
     i32: i32.createValueFromAST,
     i64: i64.createValueFromAST,
-    f32: inf ? f32.createInfFromAST : (nan ? f32.createNanFromAST : f32.createValueFromAST),
-    f64: inf ? f64.createInfFromAST :f64.createValueFromAST
+    f32: inf
+      ? f32.createInfFromAST
+      : nan ? f32.createNanFromAST : f32.createValueFromAST,
+    f64: inf ? f64.createInfFromAST : f64.createValueFromAST
   };
 
   if (typeof castFn[type] === "undefined") {

--- a/src/interpreter/runtime/castIntoStackLocalOfType.js
+++ b/src/interpreter/runtime/castIntoStackLocalOfType.js
@@ -15,11 +15,19 @@ export function castIntoStackLocalOfType(
   const castFn = {
     i32: i32.createValueFromAST,
     i64: i64.createValueFromAST,
-    f32: inf
-      ? f32.createInfFromAST
-      : nan ? f32.createNanFromAST : f32.createValueFromAST,
-    f64: inf ? f64.createInfFromAST : f64.createValueFromAST
+    f32: f32.createValueFromAST,
+    f64: f64.createValueFromAST
   };
+
+  if (nan) {
+    castFn.f32 = f32.createNanFromAST;
+    castFn.f64 = f64.createNanFromAST;
+  }
+
+  if (inf) {
+    castFn.f32 = f32.createInfFromAST;
+    castFn.f64 = f64.createInfFromAST;
+  }
 
   if (typeof castFn[type] === "undefined") {
     throw new RuntimeError("Cannot cast: unsupported type " + type);

--- a/src/interpreter/runtime/castIntoStackLocalOfType.js
+++ b/src/interpreter/runtime/castIntoStackLocalOfType.js
@@ -9,13 +9,14 @@ const f64 = require("./values/f64");
 export function castIntoStackLocalOfType(
   type: string,
   v: any,
-  nan: boolean = false
+  nan: boolean = false,
+  inf: boolean = false
 ): StackLocal {
   const castFn = {
     i32: i32.createValueFromAST,
     i64: i64.createValueFromAST,
-    f32: nan ? f32.createNanFromAST : f32.createValueFromAST,
-    f64: f64.createValueFromAST
+    f32: inf ? f32.createInfFromAST : (nan ? f32.createNanFromAST : f32.createValueFromAST),
+    f64: inf ? f64.createInfFromAST :f64.createValueFromAST
   };
 
   if (typeof castFn[type] === "undefined") {

--- a/src/interpreter/runtime/values/f32.js
+++ b/src/interpreter/runtime/values/f32.js
@@ -98,7 +98,7 @@ export class f32inf extends f32 {
     // Exponent is all 1's, mantissa is all zeros
     let result = 0xff << 23;
 
-    if(this._value < 0) {
+    if (this._value < 0) {
       result = result | 0x80000000;
     }
 

--- a/src/interpreter/runtime/values/f32.js
+++ b/src/interpreter/runtime/values/f32.js
@@ -93,7 +93,18 @@ export class f32nan extends f32 {
   }
 }
 
-export class f32inf extends f32 {}
+export class f32inf extends f32 {
+  reinterpret(): i32 {
+    // Exponent is all 1's, mantissa is all zeros
+    let result = 0xff << 23;
+
+    if(this._value < 0) {
+      result = result | 0x80000000;
+    }
+
+    return new i32(result);
+  }
+}
 
 export function createInfFromAST(sign: number): StackLocal {
   return {

--- a/src/interpreter/runtime/values/f64.js
+++ b/src/interpreter/runtime/values/f64.js
@@ -29,10 +29,19 @@ export class f64inf extends f64 {
   }
 }
 
+export class f64nan extends f64 {}
+
 export function createInfFromAST(sign: number): StackLocal {
   return {
     type,
     value: new f64inf(sign)
+  };
+}
+
+export function createNanFromAST(payload: number): StackLocal {
+  return {
+    type,
+    value: new f64nan(payload)
   };
 }
 

--- a/src/interpreter/runtime/values/f64.js
+++ b/src/interpreter/runtime/values/f64.js
@@ -16,6 +16,26 @@ export class f64 extends Float<i64> {
   }
 }
 
+export class f64inf extends f64 {
+  reinterpret(): i64 {
+    // Exponent is all 1's, mantissa is all zeros
+    let upper = 0x7ff << 20;
+
+    if(this._value < 0) {
+      upper = upper | 0x80000000;
+    }
+
+    return new i64(Long.fromBits(0, upper));
+  }
+}
+
+export function createInfFromAST(sign: number): StackLocal {
+  return {
+    type,
+    value: new f64inf(sign)
+  };
+}
+
 export function createValueFromAST(value: number): StackLocal {
   return {
     type,

--- a/src/interpreter/runtime/values/f64.js
+++ b/src/interpreter/runtime/values/f64.js
@@ -21,7 +21,7 @@ export class f64inf extends f64 {
     // Exponent is all 1's, mantissa is all zeros
     let upper = 0x7ff << 20;
 
-    if(this._value < 0) {
+    if (this._value < 0) {
       upper = upper | 0x80000000;
     }
 

--- a/src/types/AST.js
+++ b/src/types/AST.js
@@ -6,6 +6,13 @@ type U32Literal = NumberLiteral & {
   value: NumericOperations<i32>
 };
 
+type FloatLiteral = {
+  type: "FloatLiteral",
+  value: number,
+  nan?: boolean,
+  inf?: boolean
+};
+
 type Typeidx = U32Literal;
 type Funcidx = U32Literal;
 type Tableidx = U32Literal;

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -148,3 +148,5 @@ interface TableInstance {
   get(number): ?Hostfunc;
   push(Hostfunc): void;
 }
+
+type SignatureMap = { [string]: string } | [string, string];

--- a/test/interpreter/kernel/exec/conversion-instructions.js
+++ b/test/interpreter/kernel/exec/conversion-instructions.js
@@ -217,7 +217,7 @@ describe("kernel exec - conversion instructions", () => {
       ],
 
       resEqual: new i64(Long.fromString("0xfff0000000000000", false, 16))
-    },
+    }
   ];
 
   operations.forEach(op => {

--- a/test/interpreter/kernel/exec/conversion-instructions.js
+++ b/test/interpreter/kernel/exec/conversion-instructions.js
@@ -15,6 +15,22 @@ const {
   createStackFrame
 } = require("../../../../lib/interpreter/kernel/stackframe");
 
+/*::
+type TestCase = {
+  name: string,
+
+  args: Array<{
+    value: any,
+    type: string,
+    nan?: boolean,
+    inf?: boolean
+  }>,
+
+  code: Array<Node>,
+  resEqual: any
+};
+*/
+
 describe("kernel exec - conversion instructions", () => {
   const operations = [
     {
@@ -220,7 +236,7 @@ describe("kernel exec - conversion instructions", () => {
     }
   ];
 
-  operations.forEach(op => {
+  operations.forEach((op /*: TestCase */) => {
     describe(op.name, () => {
       it("should get the correct result", () => {
         const args = op.args.map(({ value, type, nan, inf }) =>

--- a/test/interpreter/kernel/exec/conversion-instructions.js
+++ b/test/interpreter/kernel/exec/conversion-instructions.js
@@ -119,6 +119,31 @@ describe("kernel exec - conversion instructions", () => {
     },
 
     {
+      name: "i32.reinterpret/f32 - positive infinity",
+
+      args: [{ value: 1, type: "f32", inf: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f32", "i32")
+      ],
+
+      resEqual: new i32(0x7f800000)
+    },
+    {
+      name: "i32.reinterpret/f32 - negative infinity",
+
+      args: [{ value: -1, type: "f32", inf: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f32", "i32")
+      ],
+
+      resEqual: new i32(0xff800000)
+    },
+
+    {
       name: "i64.reinterpret/f64 - boundary value",
 
       args: [{ value: 0.0, type: "f64" }],
@@ -168,14 +193,38 @@ describe("kernel exec - conversion instructions", () => {
       ],
 
       resEqual: new i64(Long.fromString("8000000000000000", false, 16))
-    }
+    },
+    {
+      name: "i64.reinterpret/f64 - positive infinity",
+
+      args: [{ value: 1, type: "f64", inf: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("0x7ff0000000000000", false, 16))
+    },
+    {
+      name: "i64.reinterpret/f64 - negative infinity",
+
+      args: [{ value: -1, type: "f64", inf: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("0xfff0000000000000", false, 16))
+    },
   ];
 
   operations.forEach(op => {
     describe(op.name, () => {
       it("should get the correct result", () => {
-        const args = op.args.map(({ value, type, nan }) =>
-          castIntoStackLocalOfType(type, value, nan)
+        const args = op.args.map(({ value, type, nan, inf }) =>
+          castIntoStackLocalOfType(type, value, nan, inf)
         );
 
         const stackFrame = createStackFrame(op.code, args);


### PR DESCRIPTION
This adds the necessary code and tests for the following four cases:

```
(assert_return (invoke "i64.reinterpret_f64" (f64.const -inf)) (i64.const 0xfff0000000000000))
(assert_return (invoke "i64.reinterpret_f64" (f64.const inf)) (i64.const 0x7ff0000000000000))
(assert_return (invoke "i32.reinterpret_f32" (f32.const inf)) (i32.const 0x7f800000))
(assert_return (invoke "i32.reinterpret_f32" (f32.const -inf)) (i32.const 0xff800000))
```

The code (also the one for `nan` reinterpretation) contains some operations on constants like `0xff <<23` which I left in there for the comments to make some sense and general readability. I believe these are optimized anyway either by the minifier or the engine (constants folding) anyway, but let me know if you prefer to only have the pre-computed results in there.

*Sorry for the `make fix` commits with every PR* 😁 