### PR TITLE
Implement reinterpret for f64 nans

### DIFF
--- a/test/interpreter/fixtures/instantiate-module-with-func/exec.tjs
+++ b/test/interpreter/fixtures/instantiate-module-with-func/exec.tjs
@@ -11,4 +11,3 @@ it("should have callable exports", () => {
 
   m.exports.an();
 });
-

--- a/test/interpreter/fixtures/trap-throws-runtime-error/exec.tjs
+++ b/test/interpreter/fixtures/trap-throws-runtime-error/exec.tjs
@@ -1,5 +1,9 @@
 it("should throw a runetimeError when trapped", () => {
   const m = WebAssembly.instantiateFromSource(watfmodule);
 
-  assert.throws(m.exports.trap, WebAssembly.runtimeError, "Execution has been trapped");
+  assert.throws(
+    m.exports.trap,
+    WebAssembly.runtimeError,
+    "Execution has been trapped"
+  );
 });

--- a/test/interpreter/kernel/exec/conversion-instructions.js
+++ b/test/interpreter/kernel/exec/conversion-instructions.js
@@ -233,6 +233,42 @@ describe("kernel exec - conversion instructions", () => {
       ],
 
       resEqual: new i64(Long.fromString("0xfff0000000000000", false, 16))
+    },
+    {
+      name: "i64.reinterpret/f64 - negative nan payload",
+
+      args: [{ value: -0xfffffffffffff, type: "f64", nan: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.NEG_ONE)
+    },
+    {
+      name: "i64.reinterpret/f64 - canonical nan",
+
+      args: [{ value: 0x4000000000000, type: "f64", nan: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("0x7ff4000000000000", false, 16))
+    },
+    {
+      name: "i64.reinterpret/f64 - negative canonical nan",
+
+      args: [{ value: -0x4000000000000, type: "f64", nan: true }],
+
+      code: [
+        t.instruction("get_local", [t.numberLiteral(0)]),
+        t.objectInstruction("reinterpret/f64", "i64")
+      ],
+
+      resEqual: new i64(Long.fromString("0xfff4000000000000", false, 16))
     }
   ];
 


### PR DESCRIPTION
This covers the following cases:

```wasm
(assert_return (invoke "i64.reinterpret_f64" (f64.const -nan:0xfffffffffffff)) (i64.const -1))
(assert_return (invoke "i64.reinterpret_f64" (f64.const nan)) (i64.const 0x7ff8000000000000))
(assert_return (invoke "i64.reinterpret_f64" (f64.const -nan)) (i64.const 0xfff8000000000000))
(assert_return (invoke "i64.reinterpret_f64" (f64.const nan:0x4000000000000)) (i64.const 0x7ff4000000000000))
(assert_return (invoke "i64.reinterpret_f64" (f64.const -nan:0x4000000000000)) (i64.const 0xfff4000000000000))
```